### PR TITLE
Environment Setup for Behave

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,13 @@
+import os
+import shutil
+
+scratch_dir = os.path.abspath(os.path.join(os.path.split(__file__)[0], '_scratch'))
+
+
+def before_all(context):
+    if not os.path.isdir(scratch_dir):
+        os.mkdir(scratch_dir)
+
+def after_all(context):
+    if os.path.isdir(scratch_dir):
+        shutil.rmtree(scratch_dir)


### PR DESCRIPTION
Previously, behave tests would fail if features/_scratch/ did not
exist.

This is simply solved by setting up before_all and after_all
functions to handle create and delete these directories,
respectively.
