### PR TITLE
Support BMP Images

### DIFF
--- a/pptx/parts/image.py
+++ b/pptx/parts/image.py
@@ -79,7 +79,7 @@ class Image(Part):
         """
         ext_map = {
             'GIF': 'gif', 'JPEG': 'jpg', 'PNG': 'png', 'TIFF': 'tiff',
-            'WMF': 'wmf'
+            'WMF': 'wmf', 'BMP': 'bmp'
         }
         stream.seek(0)
         format = PIL_Image.open(stream).format


### PR DESCRIPTION
| Problem | Support BMP Images (Fixes #117) |
| :-- | :-- |
| Solution | Add BMP to `def _ext_from_image_stream(stream):` |

_Note: this has been tested and works!_
