### PR TITLE
feature: FillFormat.transparency

### DIFF
--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -114,7 +114,7 @@ register_element_cls('c:xMode',            CT_LayoutMode)
 
 from .dml.color import (
     CT_HslColor, CT_Percentage, CT_PresetColor, CT_SchemeColor,
-    CT_ScRgbColor, CT_SRgbColor, CT_SystemColor
+    CT_ScRgbColor, CT_SRgbColor, CT_SystemColor, CT_Alpha
 )
 register_element_cls('a:hslClr',    CT_HslColor)
 register_element_cls('a:lumMod',    CT_Percentage)
@@ -124,6 +124,7 @@ register_element_cls('a:schemeClr', CT_SchemeColor)
 register_element_cls('a:scrgbClr',  CT_ScRgbColor)
 register_element_cls('a:srgbClr',   CT_SRgbColor)
 register_element_cls('a:sysClr',    CT_SystemColor)
+register_element_cls('a:alpha',     CT_Alpha)
 
 
 from .dml.fill import (

--- a/pptx/oxml/dml/color.py
+++ b/pptx/oxml/dml/color.py
@@ -7,7 +7,8 @@ lxml custom element classes for DrawingML-related XML elements.
 from __future__ import absolute_import
 
 from ...enum.dml import MSO_THEME_COLOR
-from ..simpletypes import ST_HexColorRGB, ST_Percentage
+from ..xmlchemy import ZeroOrOneChoice, Choice
+from ..simpletypes import ST_HexColorRGB, ST_Percentage, ST_AlphaValue
 from ..xmlchemy import BaseOxmlElement, RequiredAttribute, ZeroOrOne
 
 
@@ -17,6 +18,11 @@ class _BaseColorElement(BaseOxmlElement):
     """
     lumMod = ZeroOrOne('a:lumMod')
     lumOff = ZeroOrOne('a:lumOff')
+
+    eg_alphaChoice = ZeroOrOneChoice(
+        (Choice('a:alpha'),),
+        successors=('a:alpha',)
+    )
 
     def add_lumMod(self, value):
         """
@@ -87,3 +93,10 @@ class CT_SystemColor(_BaseColorElement):
     """
     Custom element class for <a:sysClr> element.
     """
+
+
+class CT_Alpha(BaseOxmlElement):
+    """
+    Custom element class for <a:alpha> element.
+    """
+    val = RequiredAttribute('val', ST_AlphaValue)

--- a/pptx/oxml/simpletypes.py
+++ b/pptx/oxml/simpletypes.py
@@ -434,6 +434,29 @@ class ST_HexColorRGB(BaseStringType):
             )
 
 
+class ST_AlphaValue(BaseStringType):
+    @classmethod
+    def validate(cls, value):
+        # must be string ---------------
+        str_value = cls.validate_string(value)
+
+        # must be 1 to 6 chars long----------
+        if not 0 < len(str_value) < 7:
+            raise ValueError(
+                "Alpha transparency string must be up to six characters long, got '%s'"
+                % str_value
+            )
+
+        # must parse as int --------
+        try:
+            int(str_value)
+        except ValueError:
+            raise ValueError(
+                "Alpha transparency string must be valid integer string, got '%s'"
+                % str_value
+            )
+
+
 class ST_LayoutMode(XsdStringEnumeration):
     """
     Valid values for `val` attribute on c:xMode and other elements of type


### PR DESCRIPTION
example usage:

```
shape = slide.add_shape(...)
fill = shape.fill
fill.solid()
fill.fore_color.rgb = RGBColor(...)
fill.transparency = 0.5
```
