### PR TITLE
fix: Python3 error adding image to presentation with no images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _scratch/
 /spec/gen_spec/spec*.db
 tags
 /tests/debug.py
+.idea/

--- a/pptx/package.py
+++ b/pptx/package.py
@@ -74,7 +74,7 @@ class Package(OpcPackage):
         def first_available_image_idx():
             image_idxs = sorted([
                 part.partname.idx for part in self.iter_parts()
-                if part.partname.startswith('/ppt/media/image')
+                if part.partname.startswith('/ppt/media/image') and part.partname.idx is not None
             ])
             for i, image_idx in enumerate(image_idxs):
                 idx = i + 1


### PR DESCRIPTION
Fix: Python 3 specific error when adding image to presentation with no images in main slides, but images in master template

Pycharm .idea folder added to git ignore

example:
These statements work in Python 2, but not in Python 3:
```
sorted([None, None])
3 > None

```