### PR TITLE
Add basic support for Group shapes.

### DIFF
--- a/pptx/shapes/base.py
+++ b/pptx/shapes/base.py
@@ -104,6 +104,17 @@ class BaseShape(object):
         return self._element.shape_id
 
     @property
+    def is_group(self):
+        """
+        |True| if this is a group shape, regardless whether it contains anything,
+        |False| otherwise. When |True|, the intertior objects can be accessed
+        using the ``.shapes`` property.
+        """
+        # This implementation is unconditionally False, the True version is
+        # on the Group subclass.
+        return False
+
+    @property
     def is_placeholder(self):
         """
         True if this shape is a placeholder. A shape is a placeholder if it

--- a/pptx/shapes/factory.py
+++ b/pptx/shapes/factory.py
@@ -12,6 +12,7 @@ from .autoshape import Shape
 from .base import BaseShape
 from ..enum.shapes import PP_PLACEHOLDER
 from .graphfrm import GraphicFrame
+from .group import Group
 from ..oxml.ns import qn
 from .picture import Picture
 from .placeholder import (
@@ -31,6 +32,8 @@ def BaseShapeFactory(shape_elm, parent):
         return Picture(shape_elm, parent)
     if tag_name == qn('p:graphicFrame'):
         return GraphicFrame(shape_elm, parent)
+    if tag_name == qn('p:grpSp'):
+        return Group(shape_elm, parent)
     return BaseShape(shape_elm, parent)
 
 

--- a/pptx/shapes/group.py
+++ b/pptx/shapes/group.py
@@ -16,9 +16,6 @@ class Group(BaseShape):
     """
     is_group = True
 
-    def __init__(self, el, parent):
-        super(Group, self).__init__(el, parent)
-
     @lazyproperty
     def shapes(self):
         from .shapetree import GroupShapeTree

--- a/pptx/shapes/group.py
+++ b/pptx/shapes/group.py
@@ -1,0 +1,23 @@
+# encoding: utf-8
+
+"""
+Group shape.
+"""
+
+from __future__ import absolute_import, print_function
+
+from ..util import lazyproperty
+from .base import BaseShape
+
+
+class Group(BaseShape):
+    """
+    A group shape. Contains an arbitrary number of other shape objects.
+    """
+    def __init__(self, el, parent):
+        super(Group, self).__init__(el, parent)
+
+    @lazyproperty
+    def shapes(self):
+        from .shapetree import GroupShapeTree
+        return GroupShapeTree(self, slide=self._parent._slide)

--- a/pptx/shapes/group.py
+++ b/pptx/shapes/group.py
@@ -14,6 +14,8 @@ class Group(BaseShape):
     """
     A group shape. Contains an arbitrary number of other shape objects.
     """
+    is_group = True
+
     def __init__(self, el, parent):
         super(Group, self).__init__(el, parent)
 

--- a/pptx/shapes/shapetree.py
+++ b/pptx/shapes/shapetree.py
@@ -72,7 +72,7 @@ class BaseShapeTree(object):
         Generate each child of the ``<p:spTree>`` element that corresponds to
         a shape, in the sequence they appear in the XML.
         """
-        spTree = self._slide.spTree
+        spTree = self._spTree
         for shape_elm in spTree.iter_shape_elms():
             if self._is_member_elm(shape_elm):
                 yield shape_elm

--- a/pptx/shapes/shapetree.py
+++ b/pptx/shapes/shapetree.py
@@ -367,3 +367,16 @@ class SlideShapeTree(BaseShapeTree):
         *shape_elm*.
         """
         return SlideShapeFactory(shape_elm, self)
+
+
+class GroupShapeTree(BaseShapeTree):
+    def __init__(self, group, slide=None):
+        super(GroupShapeTree, self).__init__(slide)
+        self._group = group
+
+    @property
+    def _spTree(self):
+        """
+        The ``<p:grpSp>`` element underlying this shape tree object
+        """
+        return self._group._element

--- a/tests/shapes/test_factory.py
+++ b/tests/shapes/test_factory.py
@@ -15,6 +15,7 @@ from pptx.shapes.factory import (
     BaseShapeFactory, _SlidePlaceholderFactory, SlideShapeFactory
 )
 from pptx.shapes.graphfrm import GraphicFrame
+from pptx.shapes.group import Group
 from pptx.shapes.picture import Picture
 from pptx.shapes.placeholder import _BaseSlidePlaceholder
 from pptx.shapes.shapetree import BaseShapeTree
@@ -43,12 +44,13 @@ class DescribeBaseShapeFactory(object):
     @pytest.fixture(params=['sp', 'pic', 'graphicFrame', 'grpSp', 'cxnSp'])
     def factory_fixture(
             self, request, slide_, Shape_, shape_, Picture_, picture_,
-            GraphicFrame_, graphic_frame_, BaseShape_, base_shape_):
+            GraphicFrame_, graphic_frame_, Group_, group_,
+            BaseShape_, base_shape_):
         shape_cxml, ShapeClass_, shape_mock = {
             'sp':           ('p:sp',           Shape_,        shape_),
             'pic':          ('p:pic',          Picture_,      picture_),
             'graphicFrame': ('p:graphicFrame', GraphicFrame_, graphic_frame_),
-            'grpSp':        ('p:grpSp',        BaseShape_,    base_shape_),
+            'grpSp':        ('p:grpSp',        Group_,        group_),
             'cxnSp':        ('p:cxnSp',        BaseShape_,    base_shape_),
         }[request.param]
         shape_elm = element(shape_cxml)
@@ -92,6 +94,17 @@ class DescribeBaseShapeFactory(object):
     @pytest.fixture
     def graphic_frame_(self, request):
         return instance_mock(request, GraphicFrame)
+
+    @pytest.fixture
+    def Group_(self, request, group_):
+        return class_mock(
+            request, 'pptx.shapes.factory.Group',
+            return_value=group_
+        )
+
+    @pytest.fixture
+    def group_(self, request):
+        return instance_mock(request, Group)
 
     @pytest.fixture
     def Picture_(self, request, picture_):


### PR DESCRIPTION
Example usage:

```
for shape in slide.shapes:
    if shape.is_group:
        for sub_shape in shape.shapes:
            # this is the interior shape, which will function the same as a non-grouped shape
```