### PR TITLE
handle None-indexes

### DIFF
--- a/pptx/package.py
+++ b/pptx/package.py
@@ -58,6 +58,7 @@ class Package(OpcPackage):
             image_idxs = sorted([
                 part.partname.idx for part in self.iter_parts()
                 if part.partname.startswith('/ppt/media/image')
+                and part.partname.idx is not None
             ])
             for i, image_idx in enumerate(image_idxs):
                 idx = i + 1


### PR DESCRIPTION

## Summary:
In some pptx files (possible due to them being created on google slides and then exported to pptx) images do not have the idx set (as they're part of a layout?)

## PR - Merge Checklist:
-- Verify:
- [ ] ALL tests have passed
- [ ] Code Review is done
- [ ] Documentation updated or N/A
- [ ] Dependencies satisfied