### PR TITLE
Use unicode not str for multilevel names

### DIFF
--- a/pptx/chart/xmlwriter.py
+++ b/pptx/chart/xmlwriter.py
@@ -1533,7 +1533,7 @@ class _CategorySeriesXmlWriter(_BaseSeriesXmlWriter):
                     '                  <c:pt idx="%d">\n'
                     '                    <c:v>%s</c:v>\n'
                     '                  </c:pt>\n'
-                ) % (idx, escape(str(name)))
+                ) % (idx, escape(unicode(name)))
             return xml
 
         xml = ''


### PR DESCRIPTION
Solves issue #276 

Changed `str` to `unicode`.