### PR TITLE
Proposal to turn layouts names to attributes

### DIFF
--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -367,9 +367,11 @@ class SlideLayouts(ParentedElementProxy):
             and then checks if the name is valid identifier 
             and it is available for given instance.
             """
-            new_name = name.title().replace(' ', '')
-            if new_name.isidentifier() and not hasattr(instance, new_name):
-                return new_name
+            from .compat import is_string
+            if is_string(name):
+                new_name = name.title().replace(' ', '')
+                if new_name.isidentifier() and not hasattr(instance, new_name):
+                    return new_name
 
         available_layouts = []
         for layout_id in self._sldLayoutIdLst:
@@ -380,8 +382,8 @@ class SlideLayouts(ParentedElementProxy):
             attr_name = name_to_attr(layout_name, self)
             if attr_name:
                 setattr(self, attr_name, layout)
-            if not hasattr(self, 'available_layouts'):
-                setattr(self, 'available_layouts', available_layouts)
+        if available_layouts and not hasattr(self, 'available_layouts'):
+            setattr(self, 'available_layouts', available_layouts)
 
 
 class SlideMaster(_BaseMaster):

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -327,11 +327,10 @@ class SlideLayouts(ParentedElementProxy):
     iteration.
     """
 
-    __slots__ = ('_sldLayoutIdLst',)
-
     def __init__(self, sldLayoutIdLst, parent):
         super(SlideLayouts, self).__init__(sldLayoutIdLst, parent)
         self._sldLayoutIdLst = sldLayoutIdLst
+        self._init_attrs()
 
     def __getitem__(self, idx):
         """
@@ -356,6 +355,33 @@ class SlideLayouts(ParentedElementProxy):
         Support len() built-in function (e.g. 'len(slides) == 4').
         """
         return len(self._sldLayoutIdLst)
+    
+    def _init_attrs(self):
+        """
+        Adds available layout names as attribute to `slide_layouts`.
+        Layouts can then be accessed like `slide_layouts.Blank`
+        """
+        def name_to_attr(name, instance):
+            """
+            Formats given attribute name to CamelCase removing spaces 
+            and then checks if the name is valid identifier 
+            and it is available for given instance.
+            """
+            new_name = name.title().replace(' ', '')
+            if new_name.isidentifier() and not hasattr(instance, new_name):
+                return new_name
+
+        available_layouts = []
+        for layout_id in self._sldLayoutIdLst:
+            layout_rid = layout_id.rId
+            layout = self.part.related_slide_layout(layout_rid)
+            layout_name = layout.name
+            available_layouts.append(layout_name)
+            attr_name = name_to_attr(layout_name, self)
+            if attr_name:
+                setattr(self, attr_name, layout)
+            if not hasattr(self, 'available_layouts'):
+                setattr(self, 'available_layouts', available_layouts)
 
 
 class SlideMaster(_BaseMaster):


### PR DESCRIPTION
 Turn slide layouts names to attributes

This will add slide layouts names as attributes to `SlideLayouts` instance.
All layouts names will be converted to CamelCase without spaces.
If the converted name is a valid identifier and is not used already by `slide_layouts` instance it will be assigned as an attribute to `slide_layouts`.
Also all available layouts will be available (as seen in PowerPoint) as a list accessible with attribute `slide_layouts.available_layouts`
After that - using available layouts is as easy as accessing any other attribute.

For example with the standard template available with `pptx`:

    pres = Presentation()
    print(pres.slide_layouts.available_layouts)

Will produce:

    ['Title Slide', 'Title and Content', 'Section Header', 'Two Content', 'Comparison', 'Title Only', 'Blank', 'Content with Caption', 'Picture with Caption', 'Title and Vertical Text', 'Vertical Title and Text']

And using `Title Slide` is then as easy as:

    pres.slide_layouts.TitleSlide
