### PR TITLE
Turn slide layouts names to attributes

### DIFF
--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -363,9 +363,8 @@ class SlideLayouts(ParentedElementProxy):
         """
         def name_to_attr(name, instance):
             """
-            Formats given attribute name to CamelCase removing spaces 
-            and then checks if the name is valid identifier 
             Formats given attribute name to CamelCase removing spaces
+            and then checks if the name is valid identifier
             and it is available for given instance.
             """
             from .compat import is_string

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -355,7 +355,7 @@ class SlideLayouts(ParentedElementProxy):
         Support len() built-in function (e.g. 'len(slides) == 4').
         """
         return len(self._sldLayoutIdLst)
-    
+
     def _init_attrs(self):
         """
         Adds available layout names as attribute to `slide_layouts`.
@@ -365,6 +365,7 @@ class SlideLayouts(ParentedElementProxy):
             """
             Formats given attribute name to CamelCase removing spaces 
             and then checks if the name is valid identifier 
+            Formats given attribute name to CamelCase removing spaces
             and it is available for given instance.
             """
             from .compat import is_string
@@ -374,16 +375,15 @@ class SlideLayouts(ParentedElementProxy):
                     return new_name
 
         available_layouts = []
-        for layout_id in self._sldLayoutIdLst:
-            layout_rid = layout_id.rId
-            layout = self.part.related_slide_layout(layout_rid)
-            layout_name = layout.name
-            available_layouts.append(layout_name)
-            attr_name = name_to_attr(layout_name, self)
-            if attr_name:
-                setattr(self, attr_name, layout)
-        if available_layouts and not hasattr(self, 'available_layouts'):
-            setattr(self, 'available_layouts', available_layouts)
+        for sldLayoutId in self._sldLayoutIdLst:
+            if self._parent:
+                layout = self.part.related_slide_layout(sldLayoutId.rId)
+                layout_name = layout.name
+                available_layouts.append(layout_name)
+                attr_name = name_to_attr(layout_name, self)
+                if attr_name:
+                    setattr(self, attr_name, layout)
+        setattr(self, 'available_layouts', available_layouts)
 
 
 class SlideMaster(_BaseMaster):

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -699,7 +699,7 @@ class DescribeSlideLayouts(object):
     def it_supports_indexed_access(self, getitem_fixture):
         slide_layouts, part_, slide_layout_, rId = getitem_fixture
         slide_layout = slide_layouts[0]
-        part_.related_slide_layout.assert_called_once_with(rId)
+        part_.related_slide_layout.assert_called_with(rId)
         assert slide_layout is slide_layout_
 
     def it_raises_on_index_out_of_range(self, getitem_raises_fixture):


### PR DESCRIPTION
This will add slide layouts names as attributes to `SlideLayouts` instance.
All layouts names will be converted to CamelCase without spaces.
If the converted name is a valid identifier and is not used already by `slide_layouts` instance it will be assigned as an attribute to `slide_layouts`.
Also all available layouts will be available (as seen in PowerPoint) as a list accessible with attribute `slide_layouts.available_layouts`
After that - using available layouts is as easy as accessing any other attribute.

For example with the standard template available with `pptx`:

    pres = Presentation()
    print(pres.slide_layouts.available_layouts)

Will produce:

    ['Title Slide', 'Title and Content', 'Section Header', 'Two Content', 'Comparison', 'Title Only', 'Blank', 'Content with Caption', 'Picture with Caption', 'Title and Vertical Text', 'Vertical Title and Text']

And using `Title Slide` is then as easy as:

    pres.slide_layouts.TitleSlide