### PR TITLE
Python 2.7, 3.4, and 3.6 & flake8 for syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.4"
   - "3.6"
 # command to install dependencies, e.g. pip install -r requirements.txt
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install --use-mirrors importlib; fi
   - pip install -r requirements.txt
   - pip install flake8
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: python
 python:
-  - "3.4"
-  - "3.3"
   - "2.7"
-  - "2.6"
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+  - "3.4"
+  - "3.6"
+# command to install dependencies, e.g. pip install -r requirements.txt
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install --use-mirrors importlib; fi
   - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests, e.g. python setup.py test
-sudo:    false
 script:  py.test && behave --stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install flake8
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --exclude=python2.py --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 . --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests, e.g. python setup.py test
 script:  py.test && behave --stop


### PR DESCRIPTION
Python 2.6 is EOL and 3.3 is EOL this month. Python End of Life dates:
* https://docs.python.org/devguide/index.html#branchstatus

http://flake8.pycqa.org can find syntax errors and undefined names that can halt your program.