### PR TITLE
correct-pkg-import-name

### DIFF
--- a/pptx/opc/phys_pkg.py
+++ b/pptx/opc/phys_pkg.py
@@ -11,7 +11,7 @@ import os
 from zipfile import ZipFile, is_zipfile, ZIP_DEFLATED
 
 from ..compat import is_string
-from ..exceptions import PackageNotFoundError
+from ..exc import PackageNotFoundError
 
 from .packuri import CONTENT_TYPES_URI
 


### PR DESCRIPTION
PackageNotFoundError exists in the 'exc' module rather than 'exceptions'. 'exceptions' does not exist.