### PR TITLE
added svg content-type

### DIFF
--- a/pptx/__init__.py
+++ b/pptx/__init__.py
@@ -41,6 +41,7 @@ content_type_to_part_class_map = {
     CT.JPEG:                  ImagePart,
     CT.MS_PHOTO:              ImagePart,
     CT.PNG:                   ImagePart,
+    CT.SVG:                   ImagePart,
     CT.TIFF:                  ImagePart,
     CT.X_EMF:                 ImagePart,
     CT.X_WMF:                 ImagePart,

--- a/pptx/__init__.py
+++ b/pptx/__init__.py
@@ -48,6 +48,7 @@ content_type_to_part_class_map = {
     CT.ASF:                   MediaPart,
     CT.AVI:                   MediaPart,
     CT.MOV:                   MediaPart,
+    CT.MP3:                   MediaPart,
     CT.MP4:                   MediaPart,
     CT.MPG:                   MediaPart,
     CT.MS_VIDEO:              MediaPart,

--- a/pptx/opc/constants.py
+++ b/pptx/opc/constants.py
@@ -58,6 +58,9 @@ class CONTENT_TYPE(object):
     MOV = (
         'video/quicktime'
     )
+    MP3 = (
+        'audio/mp3'
+    )
     MP4 = (
         'video/mp4'
     )

--- a/pptx/opc/constants.py
+++ b/pptx/opc/constants.py
@@ -298,6 +298,9 @@ class CONTENT_TYPE(object):
         'application/vnd.openxmlformats-officedocument.spreadsheetml.workshe'
         'et+xml'
     )
+    SVG = (
+        'image/svg+xml'
+    )
     SWF = (
         'application/x-shockwave-flash'
     )


### PR DESCRIPTION
I've added explicitly image/svg+xml as SVG content type. It allows to avoid crashes when the presentaiton already contains svg images and new picture is to be added to a slide (see #382)