### PR TITLE
Fixed the TextFrame.fit_text() method crashing on long words

### DIFF
--- a/pptx/text/layout.py
+++ b/pptx/text/layout.py
@@ -231,11 +231,20 @@ class _LineSource(object):
 
     def __iter__(self):
         """
-        Generate a (text, remainder) pair for each possible even-word line
+        Generate a (text, remainder) pair for each possible line
         break in this line source, where *text* is a str value and remainder
-        is a |_LineSource| value.
+        is a |_LineSource| value. Line breaks are possible between each word
+        or between characters of the first word.
         """
+
         words = self._text.split()
+        first_word = words[0]
+        # If the first word is long, we can linebreak in the middle of it
+        for idx in range(1, len(first_word) + 1):
+            line_text = first_word[:idx]
+            remainder_text = ' '.join([first_word[idx:]] + words[1:])
+            remainder = _LineSource(remainder_text)
+            yield _Line(line_text, remainder)
         for idx in range(1, len(words)+1):
             line_text = ' '.join(words[:idx])
             remainder_text = ' '.join(words[idx:])


### PR DESCRIPTION
TextFrame.fit_text() currently crashes when the text contains a word that would be longer than the width of the shape at full point size, as it is unable to produce an acceptable line break. Powerpoint is willing to simply line break in the middle of the word in this case, so this imitates that behavior.

Fixes #168.