### PR TITLE
Add default locations for linux fonts

### DIFF
--- a/pptx/text/fonts.py
+++ b/pptx/text/fonts.py
@@ -54,7 +54,8 @@ class FontFiles(object):
             return cls._os_x_font_directories()
         if sys.platform.startswith('win32'):
             return cls._windows_font_directories()
-        raise OSError('unsupported operating system')
+
+        return cls._linux_font_directories()
 
     @classmethod
     def _iter_font_files_in(cls, directory):
@@ -91,6 +92,22 @@ class FontFiles(object):
                 os.path.join(home, '.fonts')
             ])
         return os_x_font_dirs
+
+    @classmethod
+    def _linux_font_directories(cls):
+        """
+        Return a sequence of directory paths on a Mac in which fonts are
+        likely to be located.
+        """
+        linux_font_dirs = [
+            '/usr/share/fonts'
+        ]
+        home = os.environ.get('HOME')
+        if home is not None:
+            linux_font_dirs.extend([
+                os.path.join(home, '.fonts')
+            ])
+        return linux_font_dirs
 
     @classmethod
     def _windows_font_directories(cls):


### PR DESCRIPTION
I needed support for this library inside a docker container based on Debian.  The following changes add support for linux font directories (at least for debian and at least in the container I was using).  I didn't try the trickier thing of detecting a particular type of linux.  Feel free to take or reject.