### PR TITLE
fix package NULL problem

### DIFF
--- a/pptx/opc/package.py
+++ b/pptx/opc/package.py
@@ -547,6 +547,8 @@ class Unmarshaller(object):
         """
         for source_uri, srel in pkg_reader.iter_srels():
             source = package if source_uri == '/' else parts[source_uri]
+            if not srel.is_external and srel.target_partname.endswith("NULL"):
+                continue
             target = (srel.target_ref if srel.is_external
                       else parts[srel.target_partname])
             source.load_rel(srel.reltype, target, srel.rId, srel.is_external)

--- a/pptx/opc/pkgreader.py
+++ b/pptx/opc/pkgreader.py
@@ -94,7 +94,7 @@ class PackageReader(object):
             if srel.is_external:
                 continue
             partname = srel.target_partname
-            if partname in visited_partnames:
+            if partname in visited_partnames or partname.endswith("NULL"):
                 continue
             visited_partnames.append(partname)
             part_srels = PackageReader._srels_for(phys_reader, partname)


### PR DESCRIPTION
I had an issue with one of the srel pointers being to a NULL slidemaster, this threw a KeyError from the package. As I wanted to work on a batch of Powerpoints all using the same template, they all gave the same error. I fixed it with these changes, though perhaps there is a better place to do it..

Similar issue: https://github.com/scanny/python-pptx/issues/406

