### PR TITLE
Added title, descr, hidden properties to shape objects

### DIFF
--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -304,6 +304,10 @@ class CT_NonVisualDrawingProps(BaseOxmlElement):
     hlinkHover = ZeroOrOne("a:hlinkHover", successors=_tag_seq[2:])
     id = RequiredAttribute("id", ST_DrawingElementId)
     name = RequiredAttribute("name", XsdString)
+    descr = OptionalAttribute("descr", XsdString, default="")
+    hidden = OptionalAttribute("hidden", XsdBoolean, default=False )
+    title = OptionalAttribute("title", XsdString, default="")
+
     del _tag_seq
 
 

--- a/pptx/shapes/base.py
+++ b/pptx/shapes/base.py
@@ -133,6 +133,40 @@ class BaseShape(object):
         self._element._nvXxPr.cNvPr.name = value
 
     @property
+    def title(self):
+        """
+        Description of this shape, as per Alt Text "Title" in the GUI
+        """
+        return self._element._nvXxPr.cNvPr.title
+
+    @title.setter
+    def title(self, value):
+        self._element._nvXxPr.cNvPr.title = value
+
+    @property
+    def descr(self):
+        """
+        Description of this shape, as per Alt Text "Description" in the GUI
+        """
+        return self._element._nvXxPr.cNvPr.descr
+
+    @descr.setter
+    def descr(self, value):
+        self._element._nvXxPr.cNvPr.descr = value
+
+    @property
+    def hidden(self):
+        """
+        Hidden property of the shape. Setting it to True hides the shape
+        in the presentation.
+        """
+        return self._element._nvXxPr.cNvPr.hidden
+
+    @hidden.setter
+    def hidden(self, value):
+        self._element._nvXxPr.cNvPr.hidden = value
+
+    @property
     def part(self):
         """The package part containing this shape.
 


### PR DESCRIPTION
title and descr correspond to the values available in the GUI via Properties/Alt Text. They cna be used, for example, for shape identification during reading.

hidden allows to hide the shape in the presentation.