### PR TITLE
Removed dead return statement from _MoviePicElementCreator.new_movie_pic.

### DIFF
--- a/pptx/shapes/shapetree.py
+++ b/pptx/shapes/shapetree.py
@@ -865,7 +865,6 @@ class _MoviePicElementCreator(object):
         return cls(
             shapes, shape_id, movie_file, x, y, cx, cy, poster_frame_image, mime_type
         )._pic
-        return
 
     @property
     def _media_rId(self):


### PR DESCRIPTION
Hello,
In testing an experimental [tool my company wrote](https://sgrep.dev) for matching code patterns, I stumbled across your codebase which had a dead return statement in _MoviePicElementCreator.new_movie_pic. I took a look at it and it seems like removing the dead code doesn't affect anything, so I went ahead and removed it. :)

If you're curious, here's the rule which catches dead code after return statements. https://github.com/returntocorp/sgrep-rules/blob/cfa3d186f2690a630616c348f208c8677aaf2173/python/deadcode/return.yaml

Let me know if you have any questions!