### PR TITLE
Feature: allow specifying text in TextFrame.add_paragraph()

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -114,8 +114,8 @@ before setting the text it contains.
     p.text = "This is a second paragraph that's bold"
     p.font.bold = True
 
-    p = tf.add_paragraph()
-    p.text = "This is a third paragraph that's big"
+    # Alternative way to create a paragraph and add text immediately
+    p = tf.add_paragraph("This is a third paragraph that's big")
     p.font.size = Pt(40)
 
     prs.save('test.pptx')

--- a/docs/user/text.rst
+++ b/docs/user/text.rst
@@ -65,6 +65,10 @@ might like. Say for example you want a shape with three paragraphs::
     p.text = paragraph_strs[0]
 
     for para_str in paragraph_strs[1:]:
+        p = text_frame.add_paragraph(para_str)
+
+        # is equivalent to ...
+
         p = text_frame.add_paragraph()
         p.text = para_str
 

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -28,13 +28,16 @@ class TextFrame(Subshape):
         super(TextFrame, self).__init__(parent)
         self._element = self._txBody = txBody
 
-    def add_paragraph(self):
+    def add_paragraph(self, text=None):
         """
         Return new |_Paragraph| instance appended to the sequence of
         paragraphs contained in this text frame.
         """
         p = self._txBody.add_p()
-        return _Paragraph(p, self)
+        new_p = _Paragraph(p, self)
+        if text:
+            new_p.text = text
+        return new_p
 
     @property
     def auto_size(self):

--- a/tests/text/test_text.py
+++ b/tests/text/test_text.py
@@ -36,6 +36,11 @@ class DescribeTextFrame(object):
         text_frame.add_paragraph()
         assert text_frame._txBody.xml == expected_xml
 
+    def it_can_add_a_paragraph_with_text_to_itself(self, add_paragraph_text_fixture):
+        text_frame, expected_xml, text_to_add = add_paragraph_text_fixture
+        text_frame.add_paragraph(text_to_add)
+        assert text_frame._txBody.xml == expected_xml
+
     def it_knows_its_autosize_setting(self, autosize_get_fixture):
         text_frame, expected_value = autosize_get_fixture
         assert text_frame.auto_size == expected_value
@@ -180,6 +185,19 @@ class DescribeTextFrame(object):
         text_frame = TextFrame(element(txBody_cxml), None)
         expected_xml = xml(expected_cxml)
         return text_frame, expected_xml
+
+    @pytest.fixture(
+        params=[
+            ('p:txBody/a:bodyPr', 'p:txBody/(a:bodyPr,a:p/a:r/a:t"foobar")'),
+            ('p:txBody/(a:bodyPr,a:p)', 'p:txBody/(a:bodyPr,a:p,a:p/a:r/a:t"foobar")'),
+        ]
+    )
+    def add_paragraph_text_fixture(self, request):
+        txBody_cxml, expected_cxml = request.param
+        text_frame = TextFrame(element(txBody_cxml), None)
+        test_text = "foobar"
+        expected_xml = xml(expected_cxml)
+        return text_frame, expected_xml, test_text
 
     @pytest.fixture(
         params=[


### PR DESCRIPTION
Tackling this: https://github.com/scanny/python-pptx/issues/134

Saw this shortlist, and figured I'd tackle it since it's pretty easy. Created a new test to for creating a paragraph with text

Docs have also been updated in the quickstart and in the Text section to showcase adding with and without text.

A quick script (based off the docs) shows it adding a new paragraph (in this case, a bullet point)

```from pptx import Presentation
prs = Presentation()

bullet_slide_layout = prs.slide_layouts[1]
slide = prs.slides.add_slide(bullet_slide_layout)
shapes = slide.shapes
body_shape = shapes.placeholders[1]
tf = body_shape.text_frame
tf.add_paragraph("THIS IS TEST")
prs.save("test.pptx")```