### PR TITLE
Bug Fix: Solved bug where html string failed to be encoded

### DIFF
--- a/pptx/compat/python3.py
+++ b/pptx/compat/python3.py
@@ -35,7 +35,7 @@ def to_unicode(text):
     if isinstance(text, str):
         return text
     try:
-        return text.decode("utf-8")
+        return text.decode(eventual_encoding="utf-8")
     except AttributeError:
         raise TypeError("expected unicode string, got %s value %s" % (type(text), text))
 


### PR DESCRIPTION
The error is in the following line where .decode() is called without using the named parameter _**eventual_encoding**_. 
**pptx/compat/python3.py**:
```
def to_unicode(text):
    """Return *text* as a (unicode) str.

    *text* can be str or bytes. A bytes object is assumed to be encoded as UTF-8.
    If *text* is a str object it is returned unchanged.
    """
    if isinstance(text, str):
        return text
    try:
        # Initial line
        # return text.decode("utf-8") 
        # Updated code to mitigate bug
        return text.decode(eventual_encoding="utf-8")
    except AttributeError:
        raise TypeError("expected unicode string, got %s value %s" % (type(text), text))
```

Its because in the latest version of bs4, _**indent_level**_  is the first parameter so when you do not mention the parameter name, the wrong parameter is set with 'utf-8'. which causes an error on line `indent_space = (' ' * (indent_level - 1))`.

Check out the function definition and the line marked with the comment in 
**bs4/element.py**:

```
     def decode(self, indent_level=None,
                eventual_encoding=DEFAULT_OUTPUT_ENCODING,
                formatter="minimal"):
         ....
         ....
         space = ''
         indent_space = ''
         if indent_level is not None:
             indent_space = (' ' * (indent_level - 1)) # 
         if pretty_print:
             space = indent_space
```

So, I just modified the call to use the named parameter directly.