### PR TITLE
implementing text font strikethrough

### DIFF
--- a/docs/user/text.rst
+++ b/docs/user/text.rst
@@ -168,6 +168,7 @@ the theme color Accent 1.
     font.bold = True
     font.italic = None  # cause value to be inherited from theme
     font.color.theme_color = MSO_THEME_COLOR.ACCENT_1
+    font.strikethrough = True
 
 If you prefer, you can set the font color to an absolute RGB value. Note that
 this will not change color when the theme is changed::

--- a/pptx/oxml/simpletypes.py
+++ b/pptx/oxml/simpletypes.py
@@ -727,6 +727,18 @@ class ST_TextWrappingType(XsdTokenEnumeration):
     _members = (NONE, SQUARE)
 
 
+class ST_TextFontStrike(XsdStringEnumeration):
+    """
+    Valid values for <a:bodyPr strike=""> attribute
+    """
+
+    NO_STRIKE = "noStrike"
+    SINGLE_STRIKE = "sngStrike"
+    DOUBLE_STRIKE = "dblStrike"
+	
+    _members = (NO_STRIKE, SINGLE_STRIKE, DOUBLE_STRIKE)
+
+	
 class ST_UniversalMeasure(BaseSimpleType):
     @classmethod
     def convert_from_xml(cls, str_value):

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -27,6 +27,7 @@ from pptx.oxml.simpletypes import (
     ST_TextSpacingPoint,
     ST_TextTypeface,
     ST_TextWrappingType,
+    ST_TextFontStrike,
     XsdBoolean,
 )
 from pptx.oxml.xmlchemy import (
@@ -306,7 +307,8 @@ class CT_TextCharacterProperties(BaseOxmlElement):
     b = OptionalAttribute("b", XsdBoolean)
     i = OptionalAttribute("i", XsdBoolean)
     u = OptionalAttribute("u", MSO_TEXT_UNDERLINE_TYPE)
-
+    strike = OptionalAttribute("strike", ST_TextFontStrike)
+	
     def _new_gradFill(self):
         return CT_GradientFillProperties.new_gradFill()
 

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -10,7 +10,7 @@ from pptx.enum.dml import MSO_FILL
 from pptx.enum.lang import MSO_LANGUAGE_ID
 from pptx.enum.text import MSO_AUTO_SIZE, MSO_UNDERLINE
 from pptx.opc.constants import RELATIONSHIP_TYPE as RT
-from pptx.oxml.simpletypes import ST_TextWrappingType
+from pptx.oxml.simpletypes import ST_TextWrappingType, ST_TextFontStrike
 from pptx.shapes import Subshape
 from pptx.text.fonts import FontFiles
 from pptx.text.layout import TextFitter
@@ -308,6 +308,27 @@ class Font(object):
     @bold.setter
     def bold(self, value):
         self._rPr.b = value
+
+    @property
+    def strikethrough(self):
+        return {
+            ST_TextFontStrike.SINGLE_STRIKE: True,
+            ST_TextFontStrike.DOUBLE_STRIKE: True,
+            ST_TextFontStrike.NO_STRIKE: False,
+            None: None,
+        }[self._rPr.strike]
+
+    @strikethrough.setter
+    def strikethrough(self, value):
+        if value not in (True, False, None):
+            raise ValueError(
+                "assigned value must be True, False, or None, got %s" % value
+            )
+        self._rPr.strike = {
+            True: ST_TextFontStrike.SINGLE_STRIKE,
+            False: ST_TextFontStrike.NO_STRIKE,
+            None: None,
+        }[value]
 
     @lazyproperty
     def color(self):


### PR DESCRIPTION
I had to implement this to set strikethrough property in one of my projects. 

It does not fully implement the definition in OpenXML spec, but that is by design, to keep it simple for the user.