### PR TITLE
Updated next_partname generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _scratch/
 /spec/gen_spec/spec*.db
 tags
 /tests/debug.py
+venv


### PR DESCRIPTION
Now partnames are generated on the fly and cashed for the next iteration of slides. This update solves bottleneck mentioned in scanny#644