### PR TITLE
Fix issue with `DirPkg.__contains__` method (not-implemented)

### DIFF
--- a/tests/opc/test_serialized.py
+++ b/tests/opc/test_serialized.py
@@ -245,6 +245,16 @@ class Describe_DirPkgReader(object):
             _DirPkgReader(dir_pkg_path)[PackURI("/ppt/foobar.xml")]
         assert str(e.value) == "\"no member '/ppt/foobar.xml' in package\""
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
+    def it_knows_that_it_contains_the_blob_for_a_pack_uri(self):
+        reader = _DirPkgReader(dir_pkg_path)
+        assert PackURI("/ppt/presentation.xml") in reader
+
+    @pytest.mark.xfail(reason="WIP", strict=True)
+    def and_it_knows_that_it_does_not_contain_non_present_member(self):
+        reader = _DirPkgReader(dir_pkg_path)
+        assert PackURI("/ppt/foobar.xml") not in reader
+
 
 class Describe_ZipPkgReader(object):
     """Unit-test suite for `pptx.opc.serialized._ZipPkgReader` objects."""


### PR DESCRIPTION
This pull-request arose from running `cr.exporter` tests against the latest release of `python-pptx` (0.6.20).

The `PackageReader` uses `in` operator [on line 43](https://github.com/scanny/python-pptx/blob/master/pptx/opc/serialized.py#L43), which results in a failure, since the `_DirPkgReader` doesn't have the `__contains__` method implemented.

I've created just the unit tests to repro the issue, I'll leave the fix to you @scanny. They're also marked with `xfail`.