### PR TITLE
Let Shapes and SlidePlaceholders fulfill the Mapping interface

### DIFF
--- a/pptx/shapes/shapetree.py
+++ b/pptx/shapes/shapetree.py
@@ -2,6 +2,7 @@
 
 """The shape tree, the structure that holds a slide's shapes."""
 
+from collections.abc import Mapping
 import os
 
 from pptx.compat import BytesIO
@@ -58,7 +59,7 @@ from pptx.util import Emu, lazyproperty
 # +-- SlidePlaceholders
 
 
-class _BaseShapes(ParentedElementProxy):
+class _BaseShapes(Mapping, ParentedElementProxy):
     """
     Base class for a shape collection appearing in a slide-type object,
     include Slide, SlideLayout, and SlideMaster, providing common methods.
@@ -746,7 +747,7 @@ class NotesSlidePlaceholders(MasterPlaceholders):
         return _NotesSlideShapeFactory(placeholder_elm, self)
 
 
-class SlidePlaceholders(ParentedElementProxy):
+class SlidePlaceholders(Mapping, ParentedElementProxy):
     """
     Collection of placeholder shapes on a slide. Supports iteration,
     :func:`len`, and dictionary-style lookup on the `idx` value of the


### PR DESCRIPTION
Both are essentially mappings and define the minimal interface
for `collections.abc.Mapping` (https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes),
i.e. `__iter__`, `__getitem__` and `__len__`.

By inheriting from `Mapping` we mix in the full mapping behavior, .e.g. `.get()`
and `.key()` methods. This is to make these collections feel more pythonic.
Additionally, it's a real usability improvement: e.g. for `SlidePlaceholders`
one cannot guess the valid keys, which makes `placeholders[idx]` difficult to use.
Having `placeholders.keys()` available makes inspection much easier.