### PR TITLE
Fix AttributeError: module 'collections' has no attribute 'abc'

### DIFF
--- a/pptx/__init__.py
+++ b/pptx/__init__.py
@@ -7,6 +7,8 @@ __version__ = "0.6.21"
 
 import pptx.exc as exceptions
 import sys
+import collections
+import collections.abc
 
 sys.modules["pptx.exceptions"] = exceptions
 del sys


### PR DESCRIPTION
Fix AttributeError: module 'collections' has no attribute 'abc' in python@3.10 +