### PR TITLE
Feat: Add Alt text properties and setters

### DIFF
--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -168,6 +168,17 @@ class BaseShapeElement(BaseOxmlElement):
         return self._nvXxPr.cNvPr.name
 
     @property
+    def shape_alt_text(self):
+        """
+        Alt text of this shape
+        """
+        return self._nvXxPr.cNvPr.descr
+
+    @shape_alt_text.setter
+    def shape_alt_text(self, value):
+        self._nvXxPr.cNvPr.descr = value
+
+    @property
     def txBody(self):
         """
         Child ``<p:txBody>`` element, None if not present
@@ -304,6 +315,7 @@ class CT_NonVisualDrawingProps(BaseOxmlElement):
     hlinkHover = ZeroOrOne("a:hlinkHover", successors=_tag_seq[2:])
     id = RequiredAttribute("id", ST_DrawingElementId)
     name = RequiredAttribute("name", XsdString)
+    descr = OptionalAttribute('descr', XsdString)
     del _tag_seq
 
 

--- a/pptx/shapes/base.py
+++ b/pptx/shapes/base.py
@@ -133,6 +133,17 @@ class BaseShape(object):
         self._element._nvXxPr.cNvPr.name = value
 
     @property
+    def alt_text(self):
+        """
+        Alternative text for the shape
+        """
+        return self._element.shape_alt_text
+
+    @alt_text.setter
+    def alt_text(self, value):
+        self._element.shape_alt_text = value
+
+    @property
     def part(self):
         """The package part containing this shape.
 


### PR DESCRIPTION
Adds ability to read and set alt text. Wanted to be able to leverage this library to add in alt text for screen readers for the visually impaired

Property methods taken from @cray2015 pr: https://github.com/scanny/python-pptx/pull/512