### PR TITLE
Use UTC-aware datetime objects

### DIFF
--- a/features/steps/coreprops.py
+++ b/features/steps/coreprops.py
@@ -6,7 +6,7 @@ Gherkin step implementations for core properties-related features.
 
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from behave import given, when, then
 
@@ -67,7 +67,7 @@ def step_then_a_core_props_part_with_def_vals_is_added(context):
     assert core_props.revision == 1
     # core_props.modified only stores time with seconds resolution, so
     # comparison needs to be a little loose (within two seconds)
-    modified_timedelta = datetime.utcnow() - core_props.modified
+    modified_timedelta = datetime.now(timezone.utc) - core_props.modified
     max_expected_timedelta = timedelta(seconds=2)
     assert modified_timedelta < max_expected_timedelta
 

--- a/pptx/oxml/coreprops.py
+++ b/pptx/oxml/coreprops.py
@@ -247,7 +247,7 @@ class CT_CoreProperties(BaseOxmlElement):
         dt = None
         for tmpl in templates:
             try:
-                dt = datetime.strptime(parseable_part, tmpl)
+                dt = datetime.strptime(parseable_part, tmpl).astimezone()
             except ValueError:
                 continue
         if dt is None:

--- a/pptx/parts/coreprops.py
+++ b/pptx/parts/coreprops.py
@@ -2,7 +2,7 @@
 
 """Core properties part, corresponds to ``/docProps/core.xml`` part in package."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pptx.opc.constants import CONTENT_TYPE as CT
 from pptx.opc.package import XmlPart
@@ -27,7 +27,7 @@ class CorePropertiesPart(XmlPart):
         core_props.title = "PowerPoint Presentation"
         core_props.last_modified_by = "python-pptx"
         core_props.revision = 1
-        core_props.modified = datetime.utcnow()
+        core_props.modified = datetime.now(timezone.utc)
         return core_props
 
     @property

--- a/tests/parts/test_coreprops.py
+++ b/tests/parts/test_coreprops.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pptx.opc.constants import CONTENT_TYPE as CT
 from pptx.oxml.coreprops import CT_CoreProperties
@@ -55,7 +55,7 @@ class DescribeCorePropertiesPart(object):
         assert core_props.revision == 1
         # core_props.modified only stores time with seconds resolution, so
         # comparison needs to be a little loose (within two seconds)
-        modified_timedelta = datetime.utcnow() - core_props.modified
+        modified_timedelta = datetime.now(timezone.utc) - core_props.modified
         max_expected_timedelta = timedelta(seconds=2)
         assert modified_timedelta < max_expected_timedelta
 
@@ -70,7 +70,7 @@ class DescribeCorePropertiesPart(object):
     )
     def date_prop_get_fixture(self, request, core_properties):
         prop_name, expected_datetime = request.param
-        return core_properties, prop_name, expected_datetime
+        return core_properties, prop_name, expected_datetime.astimezone() if expected_datetime is not None else None
 
     @pytest.fixture(
         params=[


### PR DESCRIPTION
It started to produce DeprecationWarning in Python 3.12 and caused the tests to fail. This fixes the tests on Python 3.12.