### PR TITLE
Set strict_timestamps=False to ZipFile

### DIFF
--- a/pptx/opc/serialized.py
+++ b/pptx/opc/serialized.py
@@ -222,7 +222,7 @@ class _ZipPkgWriter(_PhysPkgWriter):
     @lazyproperty
     def _zipf(self):
         """`ZipFile` instance open for writing."""
-        return zipfile.ZipFile(self._pkg_file, "w", compression=zipfile.ZIP_DEFLATED)
+        return zipfile.ZipFile(self._pkg_file, "w", compression=zipfile.ZIP_DEFLATED, strict_timestamps=False)
 
 
 class _ContentTypesItem(object):


### PR DESCRIPTION
Related to https://github.com/scanny/python-pptx/issues/958

Currently if the system time is before 1980-01-01, save of new PPTX file fails due to following error:
```

Traceback (most recent call last):
  File "test.py", line 19, in main
    prs.save('test.pptx')
  File "/packages/pptx/presentation.py", line 39, in save
    self.part.save(file)
  File "/packages/pptx/parts/presentation.py", line 107, in save
    self.package.save(path_or_stream)
  File "/packages/pptx/opc/package.py", line 153, in save
    PackageWriter.write(pkg_file, self._rels, tuple(self.iter_parts()))
  File "/packages/pptx/opc/serialized.py", line 76, in write
    cls(pkg_file, pkg_rels, parts)._write()
  File "/packages/pptx/opc/serialized.py", line 81, in _write
    self._write_content_types_stream(phys_writer)
  File "/packages/pptx/opc/serialized.py", line 91, in _write_content_types_stream
    phys_writer.write(
  File "/packages/pptx/opc/serialized.py", line 220, in write
    self._zipf.writestr(pack_uri.membername, blob)
  File "/usr/local/lib/python3.9/zipfile.py", line 1783, in writestr
    zinfo = ZipInfo(filename=zinfo_or_arcname,
  File "/usr/local/lib/python3.9/zipfile.py", line 361, in __init__
    raise ValueError('ZIP does not support timestamps before 1980')
ValueError: ZIP does not support timestamps before 1980
```

There exists a flag in zipfile.ZipFile called `strict_timestamps=False` that allows creation of a new ZipFile even if system time is before 1980. In such case, ZipFile forces the timestamp to 1980-01-01:

> The strict_timestamps argument, when set to False, allows to zip files older than 1980-01-01 at the cost of setting the timestamp to 1980-01-01. Similar behavior occurs with files newer than 2107-12-31, the timestamp is also set to the limit.
([source](https://docs.python.org/3/library/zipfile.html))

This PR adds the `strict_timestamps=False` parameter