### PR TITLE
fix: #943 Docstring implies Px subtype of Length

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ---------------
 
+0.6.24-dev0
++++++++++++++++++++
+
+- fix: #943 remove mention of a Px Length subtype
+
 0.6.23 (2023-11-02)
 +++++++++++++++++++
 

--- a/src/pptx/util.py
+++ b/src/pptx/util.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Generic, TypeVar, cast
 
 
 class Length(int):
-    """Base class for length classes Inches, Emu, Cm, Mm, Pt, and Px.
+    """Base class for length classes Inches, Emu, Cm, Mm, and Pt.
 
     Provides properties for converting length values to convenient units.
     """


### PR DESCRIPTION
**Summary**
Remove mention of a `Px` subtype of `Length` since no such subtype exists. Turns out a pixel has various sizes on different systems so no standard unit of measure is possible and in any case no such type is implemented.

Fixes: #943 