### PR TITLE
fix: #972 next-slide-id fails when max used

### DIFF
--- a/tests/oxml/test_presentation.py
+++ b/tests/oxml/test_presentation.py
@@ -38,3 +38,26 @@ class DescribeCT_SlideIdList(object):
     def it_knows_the_next_available_slide_id(self, sldIdLst_cxml: str, expected_value: int):
         sldIdLst = cast(CT_SlideIdList, element(sldIdLst_cxml))
         assert sldIdLst._next_id == expected_value
+
+    @pytest.mark.parametrize(
+        ("sldIdLst_cxml", "expected_value"),
+        [
+            ("p:sldIdLst/p:sldId{id=2147483646}", 2147483647),
+            ("p:sldIdLst/p:sldId{id=2147483647}", 256),
+            # -- 2147483648 is not a valid id but shouldn't stop us from finding a one that is --
+            ("p:sldIdLst/p:sldId{id=2147483648}", 256),
+            ("p:sldIdLst/(p:sldId{id=256},p:sldId{id=2147483647})", 257),
+            ("p:sldIdLst/(p:sldId{id=256},p:sldId{id=2147483647},p:sldId{id=257})", 258),
+            # -- 245 is also not a valid id but that shouldn't change the result either --
+            ("p:sldIdLst/(p:sldId{id=245},p:sldId{id=2147483647},p:sldId{id=256})", 257),
+        ],
+    )
+    def and_it_chooses_a_valid_slide_id_when_max_slide_id_is_used_for_a_slide(
+        self, sldIdLst_cxml: str, expected_value: int
+    ):
+        sldIdLst = cast(CT_SlideIdList, element(sldIdLst_cxml))
+
+        slide_id = sldIdLst._next_id
+
+        assert 256 <= slide_id <= 2147483647
+        assert slide_id == expected_value


### PR DESCRIPTION
**Summary**
Naive "max + 1" slide-id allocation algorithm assumed that slide-ids were assigned from bottom up. Apparently some client assigns slide ids from the top (2,147,483,647) down and the naive algorithm would assign an invalid slide-id in that case.

Detect when the assigned id is out-of-range and fall-back to a robust algorithm for assigning a valid id based on a "first unused starting at bottom" policy.

Fixes: #972 