### PR TITLE
fix: #990 Turn off ZipFile strict_timestamps

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,12 @@
 Release History
 ---------------
 
-0.6.24-dev0
+0.6.24-dev3
 +++++++++++++++++++
 
 - fix: #943 remove mention of a Px Length subtype
+- fix: #972 next-slide-id fails in rare cases
+- fix: #990 do not require strict timestamps for Zip
 
 0.6.23 (2023-11-02)
 +++++++++++++++++++

--- a/src/pptx/__init__.py
+++ b/src/pptx/__init__.py
@@ -25,7 +25,7 @@ from pptx.parts.slide import (
 if TYPE_CHECKING:
     from pptx.opc.package import Part
 
-__version__ = "0.6.23"
+__version__ = "0.6.24-dev3"
 
 sys.modules["pptx.exceptions"] = exceptions
 del sys

--- a/src/pptx/opc/serialized.py
+++ b/src/pptx/opc/serialized.py
@@ -239,7 +239,9 @@ class _ZipPkgWriter(_PhysPkgWriter):
     @lazyproperty
     def _zipf(self) -> zipfile.ZipFile:
         """`ZipFile` instance open for writing."""
-        return zipfile.ZipFile(self._pkg_file, "w", compression=zipfile.ZIP_DEFLATED)
+        return zipfile.ZipFile(
+            self._pkg_file, "w", compression=zipfile.ZIP_DEFLATED, strict_timestamps=False
+        )
 
 
 class _ContentTypesItem:

--- a/tests/opc/test_serialized.py
+++ b/tests/opc/test_serialized.py
@@ -341,7 +341,9 @@ class Describe_ZipPkgWriter:
 
         zipf = pkg_writer._zipf
 
-        ZipFile_.assert_called_once_with("prs.pptx", "w", compression=zipfile.ZIP_DEFLATED)
+        ZipFile_.assert_called_once_with(
+            "prs.pptx", "w", compression=zipfile.ZIP_DEFLATED, strict_timestamps=False
+        )
         assert zipf is ZipFile_.return_value
 
     # fixtures ---------------------------------------------


### PR DESCRIPTION
**Summary**
Accommodate system dates before 1980-01-01.

This should have no effect for users with "normal" system clocks but allows the package to save files in the unusual case the system clock is set to a date prior to 1980.

Fixes: #990 