### PR TITLE
Fix typo

### DIFF
--- a/docs/dev/analysis/txt-autofit-text.rst
+++ b/docs/dev/analysis/txt-autofit-text.rst
@@ -119,7 +119,7 @@ the calculated "best fit" point size::
 Proposed |pp| behavior
 ----------------------
 
-The :meth:`TextFrame.fit_text` method produces the following side effects:
+The :meth:`TextFrame.autofit_text` method produces the following side effects:
 
 * :attr:`TextFrame.auto_size` is set to
   :attr:`MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE`


### PR DESCRIPTION
I think it was a typo, autosize from fit_text() method should be NONE.
I'm a newbie and want to ask what is the analysis section in docs? is it only for the development section? 
I'm playing around with python-pptx right now and need an approach to shape and/or size text that can be dynamic, is autofit_text a feature that doesn't exist yet and is being developed?