### PR TITLE
added Slides.remove_slide(slide_id)

### DIFF
--- a/src/pptx/oxml/presentation.py
+++ b/src/pptx/oxml/presentation.py
@@ -65,6 +65,14 @@ class CT_SlideIdList(BaseOxmlElement):
         The new `p:sldId` element has its r:id attribute set to `rId`.
         """
         return self._add_sldId(id=self._next_id, rId=rId)
+    
+    def remove_sldId(self, slide_id: int) -> None:
+        """Remove the `p:sldId` element with the specified slide ID."""
+        for sldId in self.sldId_lst:
+            if sldId.id == slide_id:
+                self.remove(sldId)
+                return
+        raise KeyError(f"no slide with id {slide_id}")
 
     @property
     def _next_id(self) -> int:

--- a/src/pptx/parts/presentation.py
+++ b/src/pptx/parts/presentation.py
@@ -33,6 +33,14 @@ class PresentationPart(XmlPart):
         rId = self.relate_to(slide_part, RT.SLIDE)
         return rId, slide_part.slide
 
+    def remove_slide(self, slide_id: int):
+        """Remove slide with `slide_id` from this presentation."""
+        for sldId in self._element.sldIdLst:
+            if sldId.id == slide_id:
+                self.drop_rel(sldId.rId)
+                return
+        raise KeyError("no slide with id %d" % slide_id)
+
     @property
     def core_properties(self) -> CorePropertiesPart:
         """A |CoreProperties| object for the presentation.

--- a/src/pptx/slide.py
+++ b/src/pptx/slide.py
@@ -272,6 +272,11 @@ class Slides(ParentedElementProxy):
         self._sldIdLst.add_sldId(rId)
         return slide
 
+    def remove_slide(self, slide_id: int) -> None:
+        """Remove slide with `slide_id` from this presentation."""
+        self.part.remove_slide(slide_id)
+        self._sldIdLst.remove_sldId(slide_id)
+
     def get(self, slide_id: int, default: Slide | None = None) -> Slide | None:
         """Return the slide identified by int `slide_id` in this presentation.
 


### PR DESCRIPTION
Adds the delete slide feature. You can do this by calling the method `Slides().remove_slide(slide_id)` on a `Slides` instance. It deletes a slide and relations, doing just the opposite of the routines in `add_slide()`. This function calls `PresentationPart().remove_slide(slide_id)` and `CT_SlideIdList().remove_sldID(slide_id)`, which were also added here. It raises a `KeyError(f"no slide with id {slide_id}")` if the specified `slide_id` does not exist.

Fixes issue #67 

Example usage:

```python

from pptx import Presentation

presentation = Presentation()
presentation.slides.add_slide(presentation.slide_layouts[6])
presentation.slides.remove_slide(presentation.slides[-1].slide_id) #removes last slide
presentation.save("my_presentation.pptx")

#output: empty presentation (no slides)
```