### PR TITLE
Fix: add Linux and custom font directories

### DIFF
--- a/docs/dev/analysis/txt-font-typeface.rst
+++ b/docs/dev/analysis/txt-font-typeface.rst
@@ -10,6 +10,11 @@ Verdana to Arial. This aspect of a font is its *typeface*, as opposed to its
 size (e.g. 18 points) or style (e.g. bold, italic).
 
 
+.. admonition:: Custom fonts folder
+
+   |pp| will search for font files on each OS default directories. A list of custom folders can also be specified by setting the ``PYTHON_PPTX_FONT_DIRECTORY`` environment variable to a colon-separated list of the paths of each fonts folder.
+
+
 Minimum viable feature
 ----------------------
 

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -23,3 +23,14 @@ Dependencies
 * lxml
 * Pillow
 * XlsxWriter (to use charting features)
+
+
+.. admonition:: Note: font availability on Linux
+
+   On most Linux distros, default PowerPoint fonts are typically unavailable. Thus, you should install them manually by either:
+
+   - Installing ``ttf-mscorefonts-installer`` package (on Ubuntu).
+   - Copying font files from the ``C:\Windows\Fonts`` folder of an existing Windows machine.
+   - Manually installing the fonts following `this guide <https://wiki.debian.org/ppviewerFonts>`_.
+
+

--- a/src/pptx/text/fonts.py
+++ b/src/pptx/text/fonts.py
@@ -43,8 +43,18 @@ class FontFiles(object):
         Return a sequence of directory paths likely to contain fonts on the
         current platform.
         """
+
+        # Colon-separated list of paths for python-pptx to find fonts
+        CUSTOM_DIRS_VAR_NAME = 'PYTHON_PPTX_FONT_DIRECTORY'
+        custom_dirs = os.getenv(CUSTOM_DIRS_VAR_NAME)
+
+        if custom_dirs is not None:
+            return custom_dirs.split(':')
+
         if sys.platform.startswith("darwin"):
             return cls._os_x_font_directories()
+        if sys.platform.startswith("linux"):
+            return cls._linux_font_directories()
         if sys.platform.startswith("win32"):
             return cls._windows_font_directories()
         raise OSError("unsupported operating system")
@@ -83,6 +93,23 @@ class FontFiles(object):
                 [os.path.join(home, "Library", "Fonts"), os.path.join(home, ".fonts")]
             )
         return os_x_font_dirs
+
+    @classmethod
+    def _linux_font_directories(cls):
+        """
+        Return a sequence of directory paths in which fonts are
+        likely to be located on most Linux.
+        """
+        linux_font_dirs = [
+            "/usr/share/fonts",
+            "/usr/local/share/fonts",
+        ]
+        home = os.environ.get("HOME")
+        if home is not None:
+            linux_font_dirs.extend(
+                [os.path.join(home, ".local", "share", "fonts"), os.path.join(home, ".fonts")]
+            )
+        return linux_font_dirs
 
     @classmethod
     def _windows_font_directories(cls):

--- a/src/pptx/text/fonts.py
+++ b/src/pptx/text/fonts.py
@@ -44,20 +44,25 @@ class FontFiles(object):
         current platform.
         """
 
+        font_dirs = []
+
         # Colon-separated list of paths for python-pptx to find fonts
         CUSTOM_DIRS_VAR_NAME = 'PYTHON_PPTX_FONT_DIRECTORY'
         custom_dirs = os.getenv(CUSTOM_DIRS_VAR_NAME)
 
-        if custom_dirs is not None:
-            return custom_dirs.split(':')
+        # Check it is not None, empty or whitespace
+        if custom_dirs and custom_dirs.strip():
+            font_dirs.extend(custom_dirs.split(':'))
 
         if sys.platform.startswith("darwin"):
-            return cls._os_x_font_directories()
-        if sys.platform.startswith("linux"):
-            return cls._linux_font_directories()
-        if sys.platform.startswith("win32"):
-            return cls._windows_font_directories()
-        raise OSError("unsupported operating system")
+            font_dirs.extend(cls._os_x_font_directories())
+        elif sys.platform.startswith("linux"):
+            font_dirs.extend(cls._linux_font_directories())
+        elif sys.platform.startswith("win32"):
+            font_dirs.extend(cls._windows_font_directories())
+        else:
+            raise OSError("unsupported operating system")
+        return font_dirs
 
     @classmethod
     def _iter_font_files_in(cls, directory):


### PR DESCRIPTION
Since PR #469 has been opened for 5 years now and is around 100 commits behind, I've opened this PR including also the suggestion from @szduda to use an environment variable to provide custom font directories in addition to looking at each OS default directories.

I've set the following default directories to look for fonts on Linux:
- `/usr/share/fonts`
- `/usr/local/share/fonts`
- `~/.local/share/fonts`
- `~/.fonts` 

All unit tests, acceptance tests (behave) and nosetests (coverage) run OK. Docs have also been updated to warn Linux users that PowerPoint fonts might not be available on their distros, and giving some tips on how to get them.

I believe this might solve the following opened issues: #973 and #796 .