### PR TITLE
Update development_practices.rst

### DIFF
--- a/docs/dev/development_practices.rst
+++ b/docs/dev/development_practices.rst
@@ -130,13 +130,13 @@ Tutorial
 The `behave tutorial`_ is well worth working through.
 
 .. _behave tutorial:
-   http://packages.python.org/behave/tutorial.html
+   https://behave.readthedocs.io/en/stable/tutorial.html
 
 And this more detailed set of `examples and tutorials`_ is great for getting
 the practicalities down.
 
 .. _examples and tutorials:
-   http://jenisys.github.com/behave.example/index.html
+   https://jenisys.github.io/behave.example/
 
 
 ``behave`` Resources
@@ -144,7 +144,6 @@ the practicalities down.
 
 * `INVEST in Good Stories, and SMART Tasks`_
 * `The Secret Ninja Cucumber Scrolls`_
-* `Behavior Driven Outside In Development Explained, Part 1`_
 * The `behave website`_ contains excellent documentation on installing and
   using behave.
 
@@ -152,10 +151,7 @@ the practicalities down.
    http://xp123.com/articles/invest-in-good-stories-and-smart-tasks/
 
 .. _`The Secret Ninja Cucumber Scrolls`:
-   http://cuke4ninja.com/sec_cucumber_jargon.html
-
-.. _`Behavior Driven Outside In Development Explained, Part 1`:
-   http://www.knwang.com/behavior-driven-outside-in-development-explai
+   https://github.com/davedf/cuke4ninja
 
 .. _behave website:
-   http://packages.python.org/behave/index.html
+   https://pypi.org/project/behave/


### PR DESCRIPTION
Update URLs giving 4xx errors:

- Behave tutorial
- Behave example github page
- Behave package website

Removed two URLs due to expired domains: knwang.com, cuke4ninja.com