### PR TITLE
fix: follow the principle of least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,12 @@ on:
       - develop
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Here is a minor change in `ci.yml`, which doesn't make some real effect but for more secure usage of actions. [GitHub official docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) introduced it. 

```
Make sure the credentials being used within workflows have the least privileges required, and be mindful that any user with write access to your repository has read access to all secrets configured in your repository.
```