### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. Do not disclose it as a public issue. This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/scanny/python-pptx/security/advisories/new).
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+- The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+- Affected version(s)
+- Impact of the issue, including how an attacker might exploit the issue
+- Step-by-step instructions to reproduce the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Full paths of source file(s) related to the manifestation of the issue
+- Configuration required to reproduce the issue
+- Log files that are related to this issue (if possible)
+- Proof-of-concept or exploit code (if possible)
+This information will help us triage your report more quickly.


### PR DESCRIPTION
I've created the SECURITY.md file considering the report vulnerability through security advisory, which is a new GitHub feature.

If you're interested in GitHub's feature, it must be activated for the repository:

Open the repo's settings
Click on Advanced Security
Click "Enable" for "Private vulnerability reporting" If you rather not enable it, there is also the possibility to receive the vulnerability report through an email. In this case just let me know what would be the email and I'll submit the change.

Besides that, feel free to edit or suggest any changes to this document. It is supposed to reflect the amount of effort the team can offer to handle vulnerabilities.