### PR TITLE
transparency support

### DIFF
--- a/src/pptx/dml/color.py
+++ b/src/pptx/dml/color.py
@@ -38,6 +38,20 @@ class ColorFormat(object):
         self._validate_brightness_value(value)
         self._color.brightness = value
 
+    @property
+    def transparency(self):
+        """
+        Read/write float value between 0.0 and 1.0 indicating the transparency
+        of this color, e.g. 0.0 is completely opaque and 1.0 is completely
+        transparent. 0.5 is 50% transparent.
+        """
+        return self._color.transparency
+
+    @transparency.setter
+    def transparency(self, value):
+        self._validate_transparency_value(value)
+        self._color.transparency = value
+
     @classmethod
     def from_colorchoice_parent(cls, eg_colorChoice_parent):
         xClr = eg_colorChoice_parent.eg_colorChoice
@@ -106,6 +120,16 @@ class ColorFormat(object):
             )
             raise ValueError(msg)
 
+    def _validate_transparency_value(self, value):
+        if value < 0.0 or value > 1.0:
+            raise ValueError("transparency must be number in range 0.0 to 1.0")
+        if isinstance(self._color, _NoneColor):
+            msg = (
+                "can't set transparency when color.type is None. Set color.rgb"
+                " or .theme_color first."
+            )
+            raise ValueError(msg)
+
 
 class _Color(object):
     """
@@ -152,6 +176,42 @@ class _Color(object):
             self._shade(value)
         else:
             self._xClr.clear_lum()
+
+    @property
+    def transparency(self):
+        """
+        Read/write float value between 0.0 and 1.0 indicating the transparency
+        of this color. 0.0 is completely opaque, 1.0 is completely transparent.
+        """
+        if self._xClr is None:
+            # NoneColor has no transparency
+            return 0.0
+        alpha = self._xClr.alpha
+        if alpha is not None:
+            # alpha.val is in range 0.0-1.0, where 1.0 = 100% opaque
+            # transparency is 1.0 - alpha.val
+            return 1.0 - alpha.val
+        # no alpha element means fully opaque (0% transparent)
+        return 0.0
+
+    @transparency.setter
+    def transparency(self, value):
+        if self._xClr is None:
+            # NoneColor cannot have transparency set
+            msg = (
+                "can't set transparency when color.type is None. Set color.rgb"
+                " or .theme_color first."
+            )
+            raise ValueError(msg)
+        if value == 0.0:
+            # fully opaque, remove alpha element
+            self._xClr.clear_alpha()
+        else:
+            # convert transparency (0.0-1.0) to alpha value (1.0-0.0)
+            # alpha = 1.0 - transparency
+            alpha_val = 1.0 - value
+            self._xClr.clear_alpha()
+            self._xClr.add_alpha(alpha_val)
 
     @property
     def color_type(self):  # pragma: no cover

--- a/src/pptx/dml/fill.py
+++ b/src/pptx/dml/fill.py
@@ -70,6 +70,22 @@ class FillFormat(object):
         """
         return self._fill.fore_color
 
+    @property
+    def transparency(self):
+        """
+        Read/write float value between 0.0 and 1.0 indicating the transparency
+        of this fill, e.g. 0.0 is completely opaque and 1.0 is completely
+        transparent. 0.5 is 50% transparent.
+
+        This property is only applicable to solid fills. For other fill types,
+        accessing this property will raise a TypeError.
+        """
+        return self._fill.transparency
+
+    @transparency.setter
+    def transparency(self, value):
+        self._fill.transparency = value
+
     def gradient(self):
         """Sets the fill type to gradient.
 
@@ -203,6 +219,18 @@ class _Fill(object):
     def pattern(self):
         """Raise TypeError for fills that do not override this property."""
         tmpl = "fill type %s has no pattern, call .patterned() first"
+        raise TypeError(tmpl % self.__class__.__name__)
+
+    @property
+    def transparency(self):
+        """Raise TypeError for fills that do not override this property."""
+        tmpl = "fill type %s has no transparency, call .solid() first"
+        raise TypeError(tmpl % self.__class__.__name__)
+
+    @transparency.setter
+    def transparency(self, value):
+        """Raise TypeError for fills that do not override this property."""
+        tmpl = "fill type %s has no transparency, call .solid() first"
         raise TypeError(tmpl % self.__class__.__name__)
 
     @property
@@ -342,6 +370,18 @@ class _SolidFill(_Fill):
     def fore_color(self):
         """Return |ColorFormat| object controlling fill color."""
         return ColorFormat.from_colorchoice_parent(self._solidFill)
+
+    @property
+    def transparency(self):
+        """
+        Read/write float value between 0.0 and 1.0 indicating the transparency
+        of this solid fill. 0.0 is completely opaque, 1.0 is completely transparent.
+        """
+        return self.fore_color.transparency
+
+    @transparency.setter
+    def transparency(self, value):
+        self.fore_color.transparency = value
 
     @property
     def type(self):

--- a/src/pptx/oxml/__init__.py
+++ b/src/pptx/oxml/__init__.py
@@ -221,6 +221,7 @@ from pptx.oxml.dml.color import (  # noqa: E402
     CT_Color,
     CT_HslColor,
     CT_Percentage,
+    CT_PositiveFixedPercentage,
     CT_PresetColor,
     CT_SchemeColor,
     CT_ScRgbColor,
@@ -228,6 +229,9 @@ from pptx.oxml.dml.color import (  # noqa: E402
     CT_SystemColor,
 )
 
+register_element_cls("a:alpha", CT_PositiveFixedPercentage)
+register_element_cls("a:alphaOff", CT_PositiveFixedPercentage)
+register_element_cls("a:alphaMod", CT_PositiveFixedPercentage)
 register_element_cls("a:bgClr", CT_Color)
 register_element_cls("a:fgClr", CT_Color)
 register_element_cls("a:hslClr", CT_HslColor)

--- a/src/pptx/oxml/dml/color.py
+++ b/src/pptx/oxml/dml/color.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pptx.enum.dml import MSO_THEME_COLOR
-from pptx.oxml.simpletypes import ST_HexColorRGB, ST_Percentage
+from pptx.oxml.simpletypes import ST_HexColorRGB, ST_Percentage, ST_PositiveFixedPercentage
 from pptx.oxml.xmlchemy import (
     BaseOxmlElement,
     Choice,
@@ -20,6 +20,9 @@ class _BaseColorElement(BaseOxmlElement):
 
     lumMod = ZeroOrOne("a:lumMod")
     lumOff = ZeroOrOne("a:lumOff")
+    alpha = ZeroOrOne("a:alpha")
+    alphaOff = ZeroOrOne("a:alphaOff")
+    alphaMod = ZeroOrOne("a:alphaMod")
 
     def add_lumMod(self, value):
         """
@@ -37,6 +40,30 @@ class _BaseColorElement(BaseOxmlElement):
         lumOff.val = value
         return lumOff
 
+    def add_alpha(self, value):
+        """
+        Return a newly added <a:alpha> child element.
+        """
+        alpha = self._add_alpha()
+        alpha.val = value
+        return alpha
+
+    def add_alphaOff(self, value):
+        """
+        Return a newly added <a:alphaOff> child element.
+        """
+        alphaOff = self._add_alphaOff()
+        alphaOff.val = value
+        return alphaOff
+
+    def add_alphaMod(self, value):
+        """
+        Return a newly added <a:alphaMod> child element.
+        """
+        alphaMod = self._add_alphaMod()
+        alphaMod.val = value
+        return alphaMod
+
     def clear_lum(self):
         """
         Return self after removing any <a:lumMod> and <a:lumOff> child
@@ -44,6 +71,16 @@ class _BaseColorElement(BaseOxmlElement):
         """
         self._remove_lumMod()
         self._remove_lumOff()
+        return self
+
+    def clear_alpha(self):
+        """
+        Return self after removing any <a:alpha>, <a:alphaOff> and <a:alphaMod> child
+        elements.
+        """
+        self._remove_alpha()
+        self._remove_alphaOff()
+        self._remove_alphaMod()
         return self
 
 
@@ -75,6 +112,14 @@ class CT_Percentage(BaseOxmlElement):
     """
 
     val = RequiredAttribute("val", ST_Percentage)
+
+
+class CT_PositiveFixedPercentage(BaseOxmlElement):
+    """
+    Custom element class for <a:alpha>, <a:alphaOff> and <a:alphaMod> elements.
+    """
+
+    val = RequiredAttribute("val", ST_PositiveFixedPercentage)
 
 
 class CT_PresetColor(_BaseColorElement):

--- a/tests/dml/test_transparency.py
+++ b/tests/dml/test_transparency.py
@@ -1,0 +1,355 @@
+"""Unit-test suite for transparency functionality in `pptx.dml` module."""
+
+from __future__ import annotations
+
+import pytest
+
+from pptx.dml.color import ColorFormat, RGBColor
+from pptx.dml.fill import FillFormat, _SolidFill
+from pptx.enum.dml import MSO_COLOR_TYPE, MSO_FILL
+
+from ..oxml.unitdata.dml import (
+    a_alpha,
+    a_solidFill,
+    an_srgbClr,
+    a_schemeClr,
+)
+from ..unitutil.cxml import element
+
+
+class DescribeColorFormatTransparency(object):
+    """Unit-test suite for ColorFormat transparency property."""
+
+    def it_knows_its_transparency_value(self, transparency_get_fixture):
+        color_format, expected_transparency = transparency_get_fixture
+        assert color_format.transparency == expected_transparency
+
+    def it_can_set_its_transparency_value(self, transparency_set_fixture):
+        color_format, transparency, expected_xml = transparency_set_fixture
+        color_format.transparency = transparency
+        assert color_format._xFill.xml == expected_xml
+
+    def it_raises_on_transparency_get_for_NoneColor(self, _NoneColor_color_format):
+        # This should not raise - NoneColor should return 0.0 transparency
+        transparency = _NoneColor_color_format.transparency
+        assert transparency == 0.0
+
+    def it_raises_on_transparency_set_for_NoneColor(self, _NoneColor_color_format):
+        with pytest.raises(ValueError):
+            _NoneColor_color_format.transparency = 0.5
+
+    def it_raises_on_assign_invalid_transparency_value(self, rgb_color_format):
+        color_format = rgb_color_format
+        with pytest.raises(ValueError):
+            color_format.transparency = 1.1
+        with pytest.raises(ValueError):
+            color_format.transparency = -0.1
+
+    def it_can_set_transparency_to_zero_removes_alpha_element(self, rgb_color_format):
+        """Setting transparency to 0.0 should remove the alpha element."""
+        color_format = rgb_color_format
+        # First set some transparency
+        color_format.transparency = 0.5
+        assert color_format._color._xClr.alpha is not None
+
+        # Then set to 0.0 - should remove alpha element
+        color_format.transparency = 0.0
+        assert color_format._color._xClr.alpha is None
+        assert color_format.transparency == 0.0
+
+    def it_can_set_transparency_to_one_creates_zero_alpha(self, rgb_color_format):
+        """Setting transparency to 1.0 should create alpha element with val=0."""
+        color_format = rgb_color_format
+        color_format.transparency = 1.0
+
+        alpha_element = color_format._color._xClr.alpha
+        assert alpha_element is not None
+        assert alpha_element.val == 0.0
+        assert color_format.transparency == 1.0
+
+    # fixtures -------------------------------------------------------
+
+    @pytest.fixture(
+        params=[
+            # no alpha element - fully opaque
+            (lambda: an_srgbClr().with_val("FF0000"), 0.0),
+            # alpha = 100000 (100% opaque) - 0% transparent
+            (lambda: an_srgbClr().with_val("FF0000").with_child(
+                a_alpha().with_val(100000)), 0.0),
+            # alpha = 50000 (50% opaque) - 50% transparent
+            (lambda: an_srgbClr().with_val("FF0000").with_child(
+                a_alpha().with_val(50000)), 0.5),
+            # alpha = 0 (0% opaque) - 100% transparent
+            (lambda: an_srgbClr().with_val("FF0000").with_child(
+                a_alpha().with_val(0)), 1.0),
+        ]
+    )
+    def transparency_get_fixture(self, request):
+        xClr_bldr_fn, expected_transparency = request.param
+        xClr_bldr = xClr_bldr_fn()
+        solidFill = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+        color_format = ColorFormat.from_colorchoice_parent(solidFill)
+        return color_format, expected_transparency
+
+    @pytest.fixture(
+        params=[
+            # Set to 0.0 (fully opaque) - should remove alpha element
+            (lambda: an_srgbClr().with_val("FF0000"), 0.0,
+             lambda: an_srgbClr().with_val("FF0000")),
+            # Set to 0.5 (50% transparent) - should add alpha=50000
+            (lambda: an_srgbClr().with_val("FF0000"), 0.5,
+             lambda: an_srgbClr().with_val("FF0000").with_child(
+                 a_alpha().with_val(50000))),
+            # Set to 1.0 (fully transparent) - should add alpha=0
+            (lambda: an_srgbClr().with_val("FF0000"), 1.0,
+             lambda: an_srgbClr().with_val("FF0000").with_child(
+                 a_alpha().with_val(0))),
+            # Set from existing alpha to different value
+            (lambda: an_srgbClr().with_val("FF0000").with_child(
+                 a_alpha().with_val(75000)), 0.3,
+             lambda: an_srgbClr().with_val("FF0000").with_child(
+                 a_alpha().with_val(70000))),
+        ]
+    )
+    def transparency_set_fixture(self, request):
+        xClr_bldr_fn, transparency, expected_xClr_bldr_fn = request.param
+
+        xClr_bldr = xClr_bldr_fn()
+        solidFill = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+        color_format = ColorFormat.from_colorchoice_parent(solidFill)
+
+        expected_xClr_bldr = expected_xClr_bldr_fn()
+        expected_xml = a_solidFill().with_nsdecls().with_child(expected_xClr_bldr).xml()
+
+        return color_format, transparency, expected_xml
+
+    @pytest.fixture
+    def rgb_color_format(self):
+        solidFill = a_solidFill().with_nsdecls().with_child(
+            an_srgbClr().with_val("FF0000")
+        ).element
+        return ColorFormat.from_colorchoice_parent(solidFill)
+
+    @pytest.fixture
+    def _NoneColor_color_format(self):
+        solidFill = a_solidFill().with_nsdecls().element
+        return ColorFormat.from_colorchoice_parent(solidFill)
+
+    # Additional validation tests
+    def it_validates_transparency_value_range(self):
+        """Test that _validate_transparency_value works correctly."""
+        from pptx.dml.color import ColorFormat
+
+        # Create a dummy ColorFormat instance for testing validation
+        xClr_bldr = an_srgbClr().with_val("FF0000")
+        solidFill = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+        color_format = ColorFormat.from_colorchoice_parent(solidFill)
+
+        # Valid values should not raise
+        color_format._validate_transparency_value(0.0)
+        color_format._validate_transparency_value(0.5)
+        color_format._validate_transparency_value(1.0)
+
+        # Invalid values should raise ValueError
+        with pytest.raises(ValueError, match="transparency must be number in range 0.0 to 1.0"):
+            color_format._validate_transparency_value(-0.1)
+        with pytest.raises(ValueError, match="transparency must be number in range 0.0 to 1.0"):
+            color_format._validate_transparency_value(1.1)
+        with pytest.raises(ValueError, match="transparency must be number in range 0.0 to 1.0"):
+            color_format._validate_transparency_value(2.0)
+
+
+class DescribeFillFormatTransparency(object):
+    """Unit-test suite for FillFormat transparency property."""
+
+    def it_delegates_transparency_to_solid_fill_object(self):
+        """Test that FillFormat delegates transparency to its _SolidFill object."""
+        # Create a _SolidFill directly
+        xClr_bldr = an_srgbClr().with_val("FF0000")
+        solidFill_elm = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+        solid_fill = _SolidFill(solidFill_elm)
+
+        # Create a FillFormat that wraps our _SolidFill
+        from pptx.dml.fill import FillFormat
+
+        # Create a simple mock parent
+        class MockParent:
+            def __init__(self):
+                self.eg_fillProperties = solidFill_elm
+
+        parent_mock = MockParent()
+        fill_format = FillFormat(parent_mock, solid_fill)
+
+        # Set transparency through FillFormat
+        fill_format.transparency = 0.3
+
+        # Verify it's delegated to the underlying solid fill
+        assert abs(fill_format._fill.transparency - 0.3) < 0.001
+        assert abs(fill_format.transparency - 0.3) < 0.001
+
+    def it_raises_on_transparency_access_for_non_solid_fills(self):
+        """Test that non-solid fills raise TypeError on transparency access."""
+        from pptx.dml.fill import FillFormat, _NoFill
+
+        # Create a FillFormat with NoFill
+        class MockParent:
+            def __init__(self):
+                self.eg_fillProperties = None
+
+        parent_mock = MockParent()
+        no_fill = _NoFill(None)
+        fill_format = FillFormat(parent_mock, no_fill)
+
+        with pytest.raises(TypeError, match="fill type .* has no transparency"):
+            fill_format.transparency
+
+    def it_raises_on_transparency_set_for_non_solid_fills(self):
+        """Test that non-solid fills raise TypeError on transparency set."""
+        from pptx.dml.fill import FillFormat, _NoFill
+
+        # Create a FillFormat with NoFill
+        class MockParent:
+            def __init__(self):
+                self.eg_fillProperties = None
+
+        parent_mock = MockParent()
+        no_fill = _NoFill(None)
+        fill_format = FillFormat(parent_mock, no_fill)
+
+        with pytest.raises(TypeError, match="fill type .* has no transparency"):
+            fill_format.transparency = 0.5
+
+
+class DescribeSolidFillTransparency(object):
+    """Unit-test suite for _SolidFill transparency property."""
+
+    def it_provides_access_to_transparency(self, solid_fill_transparency_fixture):
+        solid_fill, expected_transparency = solid_fill_transparency_fixture
+        assert abs(solid_fill.transparency - expected_transparency) < 0.001
+
+    def it_can_set_transparency(self, solid_fill_transparency_set_fixture):
+        solid_fill, transparency = solid_fill_transparency_set_fixture
+        solid_fill.transparency = transparency
+        assert abs(solid_fill.transparency - transparency) < 0.001
+
+    def it_delegates_transparency_to_fore_color(self, solid_fill_obj):
+        """Test that _SolidFill delegates transparency to its fore_color."""
+        solid_fill = solid_fill_obj
+
+        # Set transparency through _SolidFill
+        solid_fill.transparency = 0.6
+
+        # Verify it's delegated to fore_color
+        assert solid_fill.fore_color.transparency == 0.6
+        assert solid_fill.transparency == 0.6
+
+    def it_has_correct_fill_type(self, solid_fill_obj):
+        """Test that _SolidFill reports correct fill type."""
+        solid_fill = solid_fill_obj
+        assert solid_fill.type == MSO_FILL.SOLID
+
+    # fixtures -------------------------------------------------------
+
+    @pytest.fixture(
+        params=[
+            # No alpha element - fully opaque
+            (lambda: an_srgbClr().with_val("00FF00"), 0.0),
+            # Alpha = 80000 (80% opaque) - 20% transparent
+            (lambda: an_srgbClr().with_val("00FF00").with_child(
+                a_alpha().with_val(80000)), 0.2),
+            # Alpha = 30000 (30% opaque) - 70% transparent
+            (lambda: an_srgbClr().with_val("00FF00").with_child(
+                a_alpha().with_val(30000)), 0.7),
+        ]
+    )
+    def solid_fill_transparency_fixture(self, request):
+        xClr_bldr_fn, expected_transparency = request.param
+        xClr_bldr = xClr_bldr_fn()
+        solidFill_elm = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+
+        solid_fill = _SolidFill(solidFill_elm)
+        return solid_fill, expected_transparency
+
+    @pytest.fixture(
+        params=[0.0, 0.1, 0.33, 0.67, 0.9, 1.0]
+    )
+    def solid_fill_transparency_set_fixture(self, request):
+        transparency = request.param
+        xClr_bldr = an_srgbClr().with_val("00FF00")
+        solidFill_elm = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+
+        solid_fill = _SolidFill(solidFill_elm)
+        return solid_fill, transparency
+
+    @pytest.fixture
+    def solid_fill_obj(self):
+        """Create a _SolidFill object for testing."""
+        xClr_bldr = an_srgbClr().with_val("0000FF")
+        solidFill_elm = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+
+        return _SolidFill(solidFill_elm)
+
+
+class DescribeTransparencyIntegration(object):
+    """Integration tests for transparency across the entire stack."""
+
+    def it_works_end_to_end_with_solid_fill_and_color_format(self):
+        """Test transparency from ColorFormat through _SolidFill."""
+        # Create a complete fill hierarchy using _SolidFill directly
+        xClr_bldr = an_srgbClr().with_val("FF00FF")
+        solidFill_elm = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+
+        solid_fill = _SolidFill(solidFill_elm)
+
+        # Test setting transparency at _SolidFill level
+        solid_fill.transparency = 0.4
+
+        # Verify it propagates through all levels
+        assert abs(solid_fill.transparency - 0.4) < 0.001
+        assert abs(solid_fill.fore_color.transparency - 0.4) < 0.001
+
+        # Verify the underlying XML has the alpha element
+        alpha_elm = solid_fill.fore_color._color._xClr.alpha
+        assert alpha_elm is not None
+        assert abs(alpha_elm.val - 0.6) < 0.001  # 1.0 - 0.4 = 0.6 (60% opaque)
+
+    def it_handles_transparency_removal_correctly(self):
+        """Test that setting transparency to 0.0 removes alpha element."""
+        xClr_bldr = an_srgbClr().with_val("FFFF00").with_child(a_alpha().with_val(40000))
+        solidFill_elm = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+
+        solid_fill = _SolidFill(solidFill_elm)
+
+        # Verify initial transparency (40000/100000 = 0.4 opaque = 0.6 transparent)
+        assert abs(solid_fill.transparency - 0.6) < 0.001
+        assert solid_fill.fore_color._color._xClr.alpha is not None
+
+        # Set transparency to 0.0
+        solid_fill.transparency = 0.0
+
+        # Verify alpha element is removed
+        assert solid_fill.transparency == 0.0
+        assert solid_fill.fore_color._color._xClr.alpha is None
+
+    def it_handles_color_format_transparency_directly(self):
+        """Test ColorFormat transparency manipulation directly."""
+        xClr_bldr = an_srgbClr().with_val("00FFFF")
+        solidFill_elm = a_solidFill().with_nsdecls().with_child(xClr_bldr).element
+
+        color_format = ColorFormat.from_colorchoice_parent(solidFill_elm)
+
+        # Test setting various transparency values
+        test_values = [0.0, 0.25, 0.5, 0.75, 1.0]
+        for transparency in test_values:
+            color_format.transparency = transparency
+            assert abs(color_format.transparency - transparency) < 0.001
+
+            if transparency == 0.0:
+                # No alpha element for fully opaque
+                assert color_format._color._xClr.alpha is None
+            else:
+                # Alpha element should exist with correct value
+                alpha_elm = color_format._color._xClr.alpha
+                assert alpha_elm is not None
+                expected_alpha = 1.0 - transparency
+                assert abs(alpha_elm.val - expected_alpha) < 0.001

--- a/tests/oxml/unitdata/dml.py
+++ b/tests/oxml/unitdata/dml.py
@@ -70,6 +70,18 @@ def a_lumOff():
     return CT_PercentageBuilder("a:lumOff")
 
 
+def a_alpha():
+    return CT_PercentageBuilder("a:alpha")
+
+
+def a_alphaOff():
+    return CT_PercentageBuilder("a:alphaOff")
+
+
+def a_alphaMod():
+    return CT_PercentageBuilder("a:alphaMod")
+
+
 def a_prstClr():
     return CT_PresetColorBuilder()
 


### PR DESCRIPTION
# Add Comprehensive Transparency Support to python-pptx

## 🎯 Overview

This PR adds complete transparency/opacity support to python-pptx, enabling developers to control the transparency of shape fills and colors. The implementation follows the DrawingML specification and provides a clean, intuitive API across all layers of the library.

## ✨ Features Added

### 🎨 **ColorFormat Transparency**
- **Property**: `ColorFormat.transparency` (read/write, 0.0-1.0 range)
- **Behavior**: 
  - `0.0` = completely opaque (no alpha element in XML)
  - `1.0` = completely transparent (alpha=0 in XML)
  - `0.5` = 50% transparent (alpha=50000 in XML)
- **Validation**: Raises `ValueError` for values outside 0.0-1.0 range
- **NoneColor Handling**: Returns 0.0 for get, raises `ValueError` for set

### 🎨 **FillFormat Transparency**
- **Property**: `FillFormat.transparency` (read/write, 0.0-1.0 range)
- **Delegation**: Automatically delegates to underlying solid fill
- **Error Handling**: Raises `TypeError` for non-solid fill types (gradient, pattern, etc.)
- **Integration**: Works seamlessly with existing fill API

### 🎨 **_SolidFill Transparency**
- **Property**: `_SolidFill.transparency` (read/write, 0.0-1.0 range)
- **Delegation**: Delegates to `fore_color.transparency`
- **Consistency**: Maintains transparency across color changes

## 🏗️ Implementation Details

### **XML Layer (OXML)**
- **New Elements**: Added support for `<a:alpha>`, `<a:alphaOff>`, `<a:alphaMod>`
- **Element Class**: `CT_PositiveFixedPercentage` for alpha value handling
- **Registration**: Proper element registration in `__init__.py`
- **Methods**: `add_alpha()`, `clear_alpha()` for XML manipulation

### **Domain Model Layer (DML)**
- **ColorFormat**: Core transparency property with validation
- **FillFormat**: High-level transparency access for fills
- **_SolidFill**: Solid fill transparency delegation
- **_Color**: Low-level transparency implementation

## 🎯 Usage Examples

```python
from pptx import Presentation
from pptx.util import Inches

# Create presentation and add shape
prs = Presentation()
slide = prs.slides.add_slide(prs.slide_layouts[0])
shape = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, 
                               Inches(1), Inches(1), 
                               Inches(2), Inches(2))

# Set fill color and transparency
shape.fill.solid()
shape.fill.fore_color.rgb = RGBColor(255, 0, 0)  # Red
shape.fill.transparency = 0.5  # 50% transparent

# Alternative: Set transparency via color
shape.fill.fore_color.transparency = 0.3  # 30% transparent

# Check transparency
print(f"Fill transparency: {shape.fill.transparency}")
print(f"Color transparency: {shape.fill.fore_color.transparency}")
```

### **XML Structure**
```xml
<a:solidFill>
  <a:srgbClr val="FF0000">
    <a:alpha val="50000"/>  <!-- 50% opaque = 50% transparent -->
  </a:srgbClr>
</a:solidFill>
```

## 📝 Notes

- Transparency is only supported for solid fills (not gradients or patterns)
- Setting transparency to 0.0 removes the alpha element for optimal XML
- NoneColor objects cannot have transparency set (must set RGB/theme color first)
- All transparency values are validated to be in the 0.0-1.0 range



Closes #62 