### PR TITLE
Replace delimitedList with DelimitedList in cxml tests

### DIFF
--- a/tests/unitutil/cxml.py
+++ b/tests/unitutil/cxml.py
@@ -19,7 +19,7 @@ from pyparsing import (
     alphanums,
     alphas,
     dblQuotedString,
-    delimitedList,
+    DelimitedList,
     removeQuotes,
     stringEnd,
 )
@@ -254,7 +254,7 @@ def grammar():
     attr_name = Word(alphas + ":")
     attr_val = Word(alphanums + " %-./:_")
     attr_def = Group(attr_name + equal + attr_val)
-    attr_list = open_brace + delimitedList(attr_def) + close_brace
+    attr_list = open_brace + DelimitedList(attr_def) + close_brace
 
     text = dblQuotedString.setParseAction(removeQuotes)
 
@@ -271,7 +271,7 @@ def grammar():
         element("element") + Group(Optional(slash + child_node_list))("child_node_list")
     ).setParseAction(connect_node_children)
 
-    child_node_list << (open_paren + delimitedList(node) + close_paren | node)
+    child_node_list << (open_paren + DelimitedList(node) + close_paren | node)
 
     root_node = (
         element("element") + Group(Optional(slash + child_node_list))("child_node_list") + stringEnd


### PR DESCRIPTION
Updated usage of pyparsing's delimitedList to DelimitedList in the cxml test grammar for compatibility with newer pyparsing versions.
pull request to resolve issue with https://github.com/scanny/python-pptx/issues/1103