### PR TITLE
feat(text): add shrink_text_to_fit method for dynamic font resizing

### DIFF
--- a/src/pptx/text/layout.py
+++ b/src/pptx/text/layout.py
@@ -82,6 +82,8 @@ class TextFitter(tuple):
             when rendered at `point_size` using the font defined in `font_file`.
             """
             text_lines = self._wrap_lines(self._line_source, point_size)
+            if text_lines is None:
+                return False
             cy = _rendered_size("Ty", point_size, self._font_file)[1]
             return (cy * len(text_lines)) <= self._height
 
@@ -109,10 +111,16 @@ class TextFitter(tuple):
         *line_source* wrapped within this fitter when rendered at
         *point_size*.
         """
-        text, remainder = self._break_line(line_source, point_size)
+        result = self._break_line(line_source, point_size)
+        if result is None:
+            return None
+        text, remainder = result
         lines = [text]
         if remainder:
-            lines.extend(self._wrap_lines(remainder, point_size))
+            remaining_lines = self._wrap_lines(remainder, point_size)
+            if remaining_lines is None:
+                return None
+            lines.extend(remaining_lines)
         return lines
 
 

--- a/src/pptx/text/text.py
+++ b/src/pptx/text/text.py
@@ -101,6 +101,44 @@ class TextFrame(Subshape):
         font_size = self._best_fit_font_size(font_family, max_size, bold, italic, font_file)
         self._apply_fit(font_family, font_size, bold, italic)
 
+    def shrink_text_to_fit(
+        self,
+        font_family: str = "Calibri",
+        max_size: int = 18,
+        bold: bool = False,
+        italic: bool = False,
+        font_file: str | None = None,
+        min_size: int = 6,
+    ):
+        """Shrink text to fit within bounds and enable TEXT_TO_FIT_SHAPE autofit.
+
+        Similar to :meth:`fit_text`, but sets :attr:`TextFrame.auto_size` to
+        :attr:`MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE` so PowerPoint will continue to
+        auto-shrink text if it's modified later.
+
+        This method calculates the best-fit font size and applies it immediately,
+        solving the issue where PowerPoint doesn't recalculate text size on file open.
+
+        :attr:`TextFrame.auto_size` is set to :attr:`MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE`.
+        The font size will not be set larger than `max_size` points or smaller than
+        `min_size` points.
+        """
+        if self.text == "":
+            return
+
+        try:
+            font_size = self._best_fit_font_size(font_family, max_size, bold, italic, font_file)
+            if font_size is None:
+                font_size = min_size
+            else:
+                font_size = max(font_size - 2, min_size)
+        except (TypeError, RecursionError):
+            font_size = min_size
+        
+        self.word_wrap = True
+        self._set_font(font_family, font_size, bold, italic)
+        self.auto_size = MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE
+
     @property
     def margin_bottom(self) -> Length:
         """|Length| value representing the inset of text from the bottom text frame border.
@@ -261,6 +299,8 @@ class TextFrame(Subshape):
 
         def iter_rPrs(txBody: CT_TextBody) -> Iterator[CT_TextCharacterProperties]:
             for p in txBody.p_lst:
+                pPr = p.get_or_add_pPr()
+                yield pPr.get_or_add_defRPr()
                 for elm in p.content_children:
                     yield elm.get_or_add_rPr()
                 # generate a:endParaRPr for each <a:p> element

--- a/tests/text/test_text.py
+++ b/tests/text/test_text.py
@@ -197,6 +197,34 @@ class DescribeTextFrame(object):
         )
         _apply_fit_.assert_called_once_with(text_frame, family, font_size, bold, italic)
 
+    def it_fits_text_and_shrinks_with_autosize_enabled(self, request):
+        """Test shrink_text_to_fit calculates font size and sets TEXT_TO_FIT_SHAPE."""
+        family, max_size, bold, italic, font_file, font_size = (
+            "family",
+            42,
+            "bold",
+            "italic",
+            "font_file",
+            21,
+        )
+        expected_font_size = font_size - 2
+        text_prop_ = property_mock(request, TextFrame, "text")
+        text_prop_.return_value = "some text"
+        _best_fit_font_size_ = method_mock(
+            request, TextFrame, "_best_fit_font_size", return_value=font_size
+        )
+        _set_font_ = method_mock(request, TextFrame, "_set_font")
+        text_frame = TextFrame(element("p:txBody/a:bodyPr"), None)
+
+        text_frame.shrink_text_to_fit(family, max_size, bold, italic, font_file)
+
+        _best_fit_font_size_.assert_called_once_with(
+            text_frame, family, max_size, bold, italic, font_file
+        )
+        _set_font_.assert_called_once_with(text_frame, family, expected_font_size, bold, italic)
+        assert text_frame.word_wrap is True
+        assert text_frame.auto_size is MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE
+
     def it_calculates_its_best_fit_font_size_to_help_fit_text(self, size_font_fixture):
         text_frame, family, max_size, bold, italic = size_font_fixture[:5]
         FontFiles_, TextFitter_, text, extents = size_font_fixture[5:9]


### PR DESCRIPTION
# Problem & Solution: Text Autofit in python-pptx

## The Problem

When you set `text_frame.auto_size = MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE` in python-pptx, it only sets the XML flag (`a:normAutofit`). PowerPoint is supposed to recalculate the font size when opening the file, but it doesn't do it automatically - you have to manually open the file and activate/deactivate the functionality to trigger the resize.

## The Solution

I added a new method `shrink_text_to_fit()` to the `TextFrame` class that:

1. **Calculates** the optimal font size using the existing `TextFitter` class
2. **Applies** that size immediately to all text (including `defRPr`)
3. **Sets** the `TEXT_TO_FIT_SHAPE` flag so PowerPoint continues to auto-adjust if text is modified later

## Usage

```python
text_frame.shrink_text_to_fit(
    font_family="Calibri",
    max_size=24,      # Maximum font size
    min_size=6        # Minimum font size (fallback)
)
```

## Files Modified

| File | Change |
|------|--------|
| `src/pptx/text/text.py` | Added `shrink_text_to_fit()` method |
| `src/pptx/text/layout.py` | Fixed crash when text is too long to fit at any size |

I also added an unit test to, that pass.