### PR TITLE
feat(chart): doughnut hole size and first-slice angle

### DIFF
--- a/src/pptx/chart/plot.py
+++ b/src/pptx/chart/plot.py
@@ -202,6 +202,40 @@ class DoughnutPlot(_BasePlot):
     An doughnut plot.
     """
 
+    @property
+    def hole_size(self):
+        """Size of the doughnut hole as an integer percentage of chart size, in range 1..90.
+
+        The default value for a new doughnut chart is 10, representing a hole 10% the diameter of
+        the chart. Assigning a value outside the 1..90 range raises |ValueError|.
+        """
+        holeSize = self._element.holeSize
+        if holeSize is None:
+            return 10
+        return holeSize.val
+
+    @hole_size.setter
+    def hole_size(self, value):
+        holeSize = self._element.get_or_add_holeSize()
+        holeSize.val = value
+
+    @property
+    def first_slice_angle(self):
+        """Angle in degrees (0..360, clockwise from straight up) of the first slice.
+
+        The default value for a new doughnut chart is 0. Assigning a value outside 0..360 raises
+        |ValueError|.
+        """
+        firstSliceAng = self._element.firstSliceAng
+        if firstSliceAng is None:
+            return 0
+        return firstSliceAng.val
+
+    @first_slice_angle.setter
+    def first_slice_angle(self, value):
+        firstSliceAng = self._element.get_or_add_firstSliceAng()
+        firstSliceAng.val = value
+
 
 class LinePlot(_BasePlot):
     """

--- a/src/pptx/oxml/__init__.py
+++ b/src/pptx/oxml/__init__.py
@@ -124,6 +124,8 @@ from pptx.oxml.chart.plot import (  # noqa: E402
     CT_BubbleChart,
     CT_BubbleScale,
     CT_DoughnutChart,
+    CT_DoughnutHoleSize,
+    CT_FirstSliceAng,
     CT_GapAmount,
     CT_Grouping,
     CT_LineChart,
@@ -140,7 +142,9 @@ register_element_cls("c:barDir", CT_BarDir)
 register_element_cls("c:bubbleChart", CT_BubbleChart)
 register_element_cls("c:bubbleScale", CT_BubbleScale)
 register_element_cls("c:doughnutChart", CT_DoughnutChart)
+register_element_cls("c:firstSliceAng", CT_FirstSliceAng)
 register_element_cls("c:gapWidth", CT_GapAmount)
+register_element_cls("c:holeSize", CT_DoughnutHoleSize)
 register_element_cls("c:grouping", CT_Grouping)
 register_element_cls("c:lineChart", CT_LineChart)
 register_element_cls("c:overlap", CT_Overlap)

--- a/src/pptx/oxml/chart/plot.py
+++ b/src/pptx/oxml/chart/plot.py
@@ -6,8 +6,10 @@ from pptx.oxml.chart.datalabel import CT_DLbls
 from pptx.oxml.simpletypes import (
     ST_BarDir,
     ST_BubbleScale,
+    ST_FirstSliceAng,
     ST_GapAmount,
     ST_Grouping,
+    ST_HoleSize,
     ST_Overlap,
 )
 from pptx.oxml.xmlchemy import (
@@ -240,7 +242,28 @@ class CT_DoughnutChart(BaseChartElement):
     varyColors = ZeroOrOne("c:varyColors", successors=_tag_seq[1:])
     ser = ZeroOrMore("c:ser", successors=_tag_seq[2:])
     dLbls = ZeroOrOne("c:dLbls", successors=_tag_seq[3:])
+    firstSliceAng = ZeroOrOne("c:firstSliceAng", successors=_tag_seq[5:])
+    holeSize = ZeroOrOne("c:holeSize", successors=_tag_seq[5:])
     del _tag_seq
+
+
+class CT_DoughnutHoleSize(BaseOxmlElement):
+    """``<c:holeSize>`` child of ``<c:doughnutChart>``.
+
+    Expresses the size of the doughnut hole as a percentage of the chart size, an integer in the
+    range 1..90 (PowerPoint accepts 10..90 in its UI).
+    """
+
+    val = OptionalAttribute("val", ST_HoleSize, default=10)
+
+
+class CT_FirstSliceAng(BaseOxmlElement):
+    """``<c:firstSliceAng>`` child of pie/doughnut charts.
+
+    The angle (clockwise from straight up, in degrees 0..360) of the first slice.
+    """
+
+    val = OptionalAttribute("val", ST_FirstSliceAng, default=0)
 
 
 class CT_GapAmount(BaseOxmlElement):

--- a/src/pptx/oxml/simpletypes.py
+++ b/src/pptx/oxml/simpletypes.py
@@ -385,6 +385,34 @@ class ST_GapAmount(BaseIntType):
         cls.validate_int_in_range(value, 0, 500)
 
 
+class ST_HoleSize(BaseIntType):
+    """
+    String value is an integer in range 1-90, representing the doughnut hole
+    size as a percent of chart size, optionally including a '%' suffix.
+    """
+
+    @classmethod
+    def convert_from_xml(cls, str_value):
+        if "%" in str_value:
+            return cls.convert_from_percent_literal(str_value)
+        return super(ST_HoleSize, cls).convert_from_xml(str_value)
+
+    @classmethod
+    def validate(cls, value):
+        cls.validate_int_in_range(value, 1, 90)
+
+
+class ST_FirstSliceAng(BaseIntType):
+    """
+    String value is an integer in range 0-360, the angle in degrees (clockwise
+    from straight up) of the first pie/doughnut slice.
+    """
+
+    @classmethod
+    def validate(cls, value):
+        cls.validate_int_in_range(value, 0, 360)
+
+
 class ST_Grouping(XsdStringEnumeration):
     """
     Valid values for <c:grouping val=""> attribute. Overloaded for use as

--- a/tests/chart/test_plot_ext.py
+++ b/tests/chart/test_plot_ext.py
@@ -1,0 +1,55 @@
+"""Unit tests for DoughnutPlot.hole_size / .first_slice_angle (issue #493)."""
+
+import pytest
+
+from pptx.chart.data import CategoryChartData
+from pptx.chart.plot import DoughnutPlot
+from pptx.enum.chart import XL_CHART_TYPE
+from pptx.oxml.ns import qn
+from pptx.util import Inches
+
+from ..unitutil.cxml import element
+
+
+def _doughnut_plot():
+    data = CategoryChartData()
+    data.categories = ["A", "B", "C"]
+    data.add_series("S", (1, 2, 3))
+    from pptx import Presentation
+
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])
+    gframe = slide.shapes.add_chart(
+        XL_CHART_TYPE.DOUGHNUT, Inches(1), Inches(1), Inches(5), Inches(4), data
+    )
+    return gframe.chart.plots[0]
+
+
+class DescribeDoughnutPlotHoleSize:
+    def it_defaults_to_10_when_absent(self):
+        plot = DoughnutPlot(element("c:doughnutChart"), None)
+        assert plot.hole_size == 10
+
+    def it_reads_and_writes_hole_size(self):
+        plot = _doughnut_plot()
+        plot.hole_size = 60
+        assert plot.hole_size == 60
+        assert plot._element.find(qn("c:holeSize")).get("val") == "60"
+
+    def it_reads_and_writes_first_slice_angle(self):
+        plot = _doughnut_plot()
+        plot.first_slice_angle = 90
+        assert plot.first_slice_angle == 90
+        assert plot._element.find(qn("c:firstSliceAng")).get("val") == "90"
+
+    @pytest.mark.parametrize("bad", [0, 91, 200])
+    def it_rejects_out_of_range_hole_size(self, bad):
+        plot = _doughnut_plot()
+        with pytest.raises(ValueError):
+            plot.hole_size = bad
+
+    @pytest.mark.parametrize("bad", [-1, 361])
+    def it_rejects_out_of_range_angle(self, bad):
+        plot = _doughnut_plot()
+        with pytest.raises(ValueError):
+            plot.first_slice_angle = bad


### PR DESCRIPTION
Implements the long-standing request (issue #493) to control the doughnut chart hole through the API, plus the sibling rotation control:

- DoughnutPlot.hole_size (c:holeSize@val, 1..90, default 10)
- DoughnutPlot.first_slice_angle (c:firstSliceAng@val, 0..360, default 0)

Adds CT_DoughnutHoleSize/CT_FirstSliceAng element classes, accessors on CT_DoughnutChart, and ST_HoleSize/ST_FirstSliceAng simple types with range validation. Tests: tests/chart/test_plot_ext.py (6); upstream tests/chart & tests/oxml unchanged.